### PR TITLE
Add Metafacture source dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,1 @@
 language: java
-before_install: sh install_core_snapshot.sh

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Go to the Git repository root:
 
 `cd metafacture-fix/`
 
-Install the metafacture-core `master-SNAPSHOT`:
-
-`sh install_core_snapshot.sh`
-
 Run the tests (in `org.metafacture.fix/src/test/java`) and checks (`.editorconfig`, `config/checkstyle/checkstyle.xml`):
 
 `./gradlew clean check`

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects {
       'jquery':      '3.3.1-1',
       'junit_jupiter':  '5.4.2',
       'junit_platform': '1.4.2',
-      'metafacture': 'master-SNAPSHOT',
+      'metafacture': '5.0.1',
       'mockito':     '2.27.0',
       'requirejs':   '2.3.6',
       'slf4j':       '1.7.21',
@@ -46,7 +46,6 @@ subprojects {
 
   repositories {
     jcenter()
-    mavenLocal()
   }
 
   dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -21,16 +21,16 @@ subprojects {
 
   ext {
     versions = [
-      'ace':         '1.3.3',
-      'jetty':       '9.4.14.v20181114',
-      'jquery':      '3.3.1-1',
+      'ace':            '1.3.3',
+      'jetty':          '9.4.14.v20181114',
+      'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.4.2',
       'junit_platform': '1.4.2',
-      'metafacture': '5.0.1',
-      'mockito':     '2.27.0',
-      'requirejs':   '2.3.6',
-      'slf4j':       '1.7.21',
-      'xtext':       '2.17.0'
+      'metafacture':    'master',
+      'mockito':        '2.27.0',
+      'requirejs':      '2.3.6',
+      'slf4j':          '1.7.21',
+      'xtext':          '2.17.0'
     ]
   }
 

--- a/install_core_snapshot.sh
+++ b/install_core_snapshot.sh
@@ -1,5 +1,0 @@
-cd ..
-git clone https://github.com/metafacture/metafacture-core.git
-cd metafacture-core
-./gradlew install
-cd ../metafacture-fix

--- a/org.metafacture.fix.web/build.gradle
+++ b/org.metafacture.fix.web/build.gradle
@@ -16,12 +16,12 @@ dependencies {
   providedCompile "org.eclipse.jetty:jetty-annotations:${versions.jetty}"
   providedCompile "org.slf4j:slf4j-simple:${versions.slf4j}"
 
-  implementation "org.metafacture:metafacture-commons:${versions.metafacture}"
-  implementation "org.metafacture:metafacture-formeta:${versions.metafacture}"
-  implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"
-  implementation "org.metafacture:metafacture-runner:${versions.metafacture}"
-  implementation "org.metafacture:metafacture-xml:${versions.metafacture}"
-  implementation "org.metafacture:metamorph:${versions.metafacture}"
+  implementation('org.metafacture:metafacture-commons') { version { branch = versions.metafacture } }
+  implementation('org.metafacture:metafacture-formeta') { version { branch = versions.metafacture } }
+  implementation('org.metafacture:metafacture-mangling') { version { branch = versions.metafacture } }
+  implementation('org.metafacture:metafacture-runner') { version { branch = versions.metafacture } }
+  implementation('org.metafacture:metafacture-xml') { version { branch = versions.metafacture } }
+  implementation('org.metafacture:metamorph') { version { branch = versions.metafacture } }
 }
 
 task jettyRun(type: JavaExec) {

--- a/org.metafacture.fix/build.gradle
+++ b/org.metafacture.fix/build.gradle
@@ -14,9 +14,9 @@ dependencies {
 
   testRuntime "org.junit.jupiter:junit-jupiter-engine:${versions.junit_jupiter}"
 
-  implementation "org.metafacture:metafacture-commons:${versions.metafacture}"
-  implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"
-  implementation "org.metafacture:metamorph:${versions.metafacture}"
+  implementation('org.metafacture:metafacture-commons') { version { branch = versions.metafacture } }
+  implementation('org.metafacture:metafacture-mangling') { version { branch = versions.metafacture } }
+  implementation('org.metafacture:metamorph') { version { branch = versions.metafacture } }
 
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
   testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,14 @@
+sourceControl {
+  gitRepository('https://github.com/metafacture/metafacture-core.git') {
+    producesModule('org.metafacture:metafacture-commons')
+    producesModule('org.metafacture:metafacture-formeta')
+    producesModule('org.metafacture:metafacture-mangling')
+    producesModule('org.metafacture:metafacture-runner')
+    producesModule('org.metafacture:metafacture-xml')
+    producesModule('org.metafacture:metamorph')
+  }
+}
+
 include 'org.metafacture.fix'
 include 'org.metafacture.fix.ide'
 include 'org.metafacture.fix.web'


### PR DESCRIPTION
TBH, I'm not really happy with the newly introduced metafacture-core master-SNAPSHOT dependency (6382371). What about leveraging [Gradle source dependencies](https://blog.gradle.org/introducing-source-dependencies) instead?