### PR TITLE
Rename group and artifact ID, update build setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish package to GitHub Packages
+on:
+  push:
+    branches:
+      - 'publish'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Publish package
+        run: ./gradlew publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects {
   apply plugin: 'eclipse'
   apply plugin: 'java'
   apply plugin: 'org.xtext.builder'
+  apply plugin: 'maven-publish'
 
   apply from: "${rootDir}/gradle/source-layout.gradle"
 
@@ -72,6 +73,35 @@ subprojects {
     }
 
     options.compilerArgs << '-Werror'
+  }
+
+  publishing {
+    publications {
+      mavenArtifacts(MavenPublication) {
+        from components.java
+        afterEvaluate {
+          groupId = project.group
+          artifactId = project.name
+        }
+      }
+    }
+    repositories {
+      maven {
+        name = 'LocalEmbedded'
+        // run generated gradle task `./gradlew
+        // publishMavenArtifactsPublicationToLocalEmbeddedRepository`
+        // to publish all subprojects into the same local embedded repo:
+        url = "file://${rootDir}/build/repo"
+      }
+      maven {
+        name = "GitHubPackages"
+        url = "https://maven.pkg.github.com/metafacture/metafacture-fix"
+        credentials {
+          username = System.getenv("GITHUB_ACTOR")
+          password = System.getenv("GITHUB_TOKEN")
+        }
+      }
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,6 @@ editorconfig {
 check.dependsOn(editorconfigCheck)
 
 subprojects {
-  group = 'org.metafacture.fix'
-  version = '1.0.0-SNAPSHOT'
 
   ext {
     versions = [
@@ -36,6 +34,9 @@ subprojects {
       'xtext':          '2.17.0'
     ]
   }
+
+  group = 'org.metafacture'
+  version = "${versions.metafacture}"
 
   apply plugin: 'checkstyle'
   apply plugin: 'eclipse'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'org.ec4j.editorconfig' version '0.0.3'
   id 'org.xtext.builder' version '2.0.8'
+  id 'io.github.0ffz.github-packages' version '1.2.1'
 }
 
 editorconfig {
@@ -50,6 +51,7 @@ subprojects {
 
   repositories {
     jcenter()
+    maven githubPackage.invoke("metafacture")
   }
 
   dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
       'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.4.2',
       'junit_platform': '1.4.2',
-      'metafacture':    'master',
+      'metafacture':    '5.2.0',
       'mockito':        '2.27.0',
       'requirejs':      '2.3.6',
       'slf4j':          '1.7.21',
@@ -36,7 +36,7 @@ subprojects {
   }
 
   group = 'org.metafacture'
-  version = "${versions.metafacture}"
+  version = '0.2.0-SNAPSHOT'
 
   apply plugin: 'checkstyle'
   apply plugin: 'eclipse'

--- a/org.metafacture.fix.ide/build.gradle
+++ b/org.metafacture.fix.ide/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  compile project(':org.metafacture.fix')
+  compile project(':metafacture-fix')
 
   compile "org.eclipse.xtext:org.eclipse.xtext.ide:${versions.xtext}"
   compile "org.eclipse.xtext:org.eclipse.xtext.xbase.ide:${versions.xtext}"

--- a/org.metafacture.fix.web/build.gradle
+++ b/org.metafacture.fix.web/build.gradle
@@ -16,12 +16,12 @@ dependencies {
   providedCompile "org.eclipse.jetty:jetty-annotations:${versions.jetty}"
   providedCompile "org.slf4j:slf4j-simple:${versions.slf4j}"
 
-  implementation('org.metafacture:metafacture-commons') { version { branch = versions.metafacture } }
-  implementation('org.metafacture:metafacture-formeta') { version { branch = versions.metafacture } }
-  implementation('org.metafacture:metafacture-mangling') { version { branch = versions.metafacture } }
-  implementation('org.metafacture:metafacture-runner') { version { branch = versions.metafacture } }
-  implementation('org.metafacture:metafacture-xml') { version { branch = versions.metafacture } }
-  implementation('org.metafacture:metamorph') { version { branch = versions.metafacture } }
+  implementation "org.metafacture:metafacture-commons:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-formeta:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-runner:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-xml:${versions.metafacture}"
+  implementation "org.metafacture:metamorph:${versions.metafacture}"
 }
 
 task jettyRun(type: JavaExec) {

--- a/org.metafacture.fix.web/build.gradle
+++ b/org.metafacture.fix.web/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  compile project(':org.metafacture.fix')
+  compile project(':metafacture-fix')
   compile project(':org.metafacture.fix.ide')
 
   compile "org.eclipse.xtend:org.eclipse.xtend.lib:${versions.xtext}"

--- a/org.metafacture.fix/build.gradle
+++ b/org.metafacture.fix/build.gradle
@@ -14,9 +14,9 @@ dependencies {
 
   testRuntime "org.junit.jupiter:junit-jupiter-engine:${versions.junit_jupiter}"
 
-  implementation('org.metafacture:metafacture-commons') { version { branch = versions.metafacture } }
-  implementation('org.metafacture:metafacture-mangling') { version { branch = versions.metafacture } }
-  implementation('org.metafacture:metamorph') { version { branch = versions.metafacture } }
+  implementation "org.metafacture:metafacture-commons:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"
+  implementation "org.metafacture:metamorph:${versions.metafacture}"
 
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
   testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,3 @@
-sourceControl {
-  gitRepository('https://github.com/metafacture/metafacture-core.git') {
-    producesModule('org.metafacture:metafacture-commons')
-    producesModule('org.metafacture:metafacture-formeta')
-    producesModule('org.metafacture:metafacture-mangling')
-    producesModule('org.metafacture:metafacture-runner')
-    producesModule('org.metafacture:metafacture-xml')
-    producesModule('org.metafacture:metamorph')
-  }
-}
-
 include 'org.metafacture.fix'
 include 'org.metafacture.fix.ide'
 include 'org.metafacture.fix.web'

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,3 +12,6 @@ sourceControl {
 include 'org.metafacture.fix'
 include 'org.metafacture.fix.ide'
 include 'org.metafacture.fix.web'
+
+// change subproject name
+project(":org.metafacture.fix").name = "metafacture-fix"


### PR DESCRIPTION
Will resolve #45 and contains other build related changes. See commits for details.

This should make the approach suggested in https://github.com/metafacture/metafacture-playground/pull/19 work (which I'll update to use `org.metafacture/metafacture-fix "0.2.0-SNAPSHOT"` after this is merged). With [OERSI consuming GitHub Packages](https://gitlab.com/oersi/oersi-etl/-/issues/59), this should allow us to get rid of the long running `oersi` branches here and in core.