### PR TITLE
Basic if statements and record mode draft

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ subprojects {
       'mockito':        '2.27.0',
       'requirejs':      '2.3.6',
       'slf4j':          '1.7.21',
-      'xtext':          '2.17.0'
+      'xtext':          '2.17.0',
+      'guava':          '29.0-jre'
     ]
   }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -7,6 +7,7 @@
         <property name="checks" value=".*"/>
         <property name="files" value="xtext-gen"/>
     </module>
+    <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
         <module name="AbstractClassName"/>
         <module name="AnnotationUseStyle"/>
@@ -145,6 +146,7 @@
             <property name="checkFormat" value="$1"/>
             <property name="commentFormat" value="checkstyle-disable-line (\w+(?:\|\w+)?)"/>
         </module>
+        <module name="SuppressWarningsHolder" />
         <module name="ThrowsCount">
             <property name="max" value="2"/>
         </module>

--- a/org.metafacture.fix/build.gradle
+++ b/org.metafacture.fix/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
   compile "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
   compile "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
+  compile "com.google.guava:guava:${versions.guava}"
 
   testCompile "org.junit.jupiter:junit-jupiter-api:${versions.junit_jupiter}"
   testCompile "org.junit.platform:junit-platform-launcher:${versions.junit_platform}"

--- a/org.metafacture.fix/src/main/java/org/metafacture/metamorph/FixBuilder.java
+++ b/org.metafacture.fix/src/main/java/org/metafacture/metamorph/FixBuilder.java
@@ -239,16 +239,21 @@ public class FixBuilder { // checkstyle-disable-line ClassDataAbstractionCouplin
 
     private boolean testConditional(final String conditional, final EList<String> p) {
         System.out.printf("<IF>: %s p: %s\n", conditional, p);
+        boolean result = false;
+        final String field = resolvedAttribute(p, 1);
+        final String value = resolvedAttribute(p, 2);
+        final Multimap<String, String> map = metafix.getCurrentRecord();
+        System.out.printf("<%s>: field: %s value: %s in: %s\n", conditional, field, value, map);
         switch (conditional) {
             case "any_match":
-                final String field = resolvedAttribute(p, 1);
-                final String value = resolvedAttribute(p, 2);
-                final Multimap<String, String> map = metafix.getCurrentRecord();
-                System.out.printf("<any_match>: field: %s value: %s in: %s\n", field, value, map);
-                return map.containsKey(field) && map.get(field).stream().anyMatch(v -> v.matches(value));
+                result = map.containsKey(field) && map.get(field).stream().anyMatch(v -> v.matches(value));
+                break;
+            case "all_match":
+                result = map.containsKey(field) && map.get(field).stream().allMatch(v -> v.matches(value));
+                break;
             default:
-                return false;
         }
+        return result;
     }
 
     private void processFunction(final Expression expression, final List<String> params, final String source) {

--- a/org.metafacture.fix/src/main/java/org/metafacture/metamorph/FixBuilder.java
+++ b/org.metafacture.fix/src/main/java/org/metafacture/metamorph/FixBuilder.java
@@ -20,6 +20,7 @@ import org.metafacture.commons.StringUtil;
 import org.metafacture.fix.fix.Do;
 import org.metafacture.fix.fix.Expression;
 import org.metafacture.fix.fix.Fix;
+import org.metafacture.fix.fix.If;
 import org.metafacture.fix.fix.MethodCall;
 import org.metafacture.fix.fix.Options;
 import org.metafacture.metamorph.api.Collect;
@@ -54,6 +55,7 @@ public class FixBuilder { // checkstyle-disable-line ClassDataAbstractionCouplin
     static final String ARRAY_MARKER = "[]";
     private static final String FLUSH_WITH = "flushWith";
     private static final String RECORD = "record";
+
     private final Deque<StackFrame> stack = new LinkedList<>();
     private final InterceptorFactory interceptorFactory;
     private final Metafix metafix;
@@ -218,9 +220,33 @@ public class FixBuilder { // checkstyle-disable-line ClassDataAbstractionCouplin
             if (sub instanceof Do) {
                 processBind(sub, p);
             }
+            else if (sub instanceof If) {
+                processConditional(sub, p);
+            }
             else {
                 processFunction(sub, p, source);
             }
+        }
+    }
+
+    private void processConditional(final Expression expression, final EList<String> p) {
+        final If theIf = (If) expression;
+        if (testConditional(theIf.getName(), p)) {
+            processSubexpressions(theIf.getElements(), resolvedAttribute(p, 1));
+        }
+    }
+
+    private boolean testConditional(final String conditional, final EList<String> p) {
+        System.out.printf("<IF>: %s p: %s\n", conditional, p);
+        switch (conditional) {
+            case "any_match":
+                final String field = resolvedAttribute(p, 1);
+                final String value = resolvedAttribute(p, 2);
+                System.out.printf("<any_match>: field: %s value: %s\n", field, value);
+                // TODO: get all fields named <field>, test if any matches <value>
+                return true;
+            default:
+                return false;
         }
     }
 

--- a/org.metafacture.fix/src/main/java/org/metafacture/metamorph/FixBuilder.java
+++ b/org.metafacture.fix/src/main/java/org/metafacture/metamorph/FixBuilder.java
@@ -32,6 +32,7 @@ import org.metafacture.metamorph.functions.Constant;
 import org.metafacture.metamorph.functions.NotEquals;
 import org.metafacture.metamorph.functions.Replace;
 
+import com.google.common.collect.Multimap;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtext.xbase.lib.Pair;
 
@@ -242,9 +243,9 @@ public class FixBuilder { // checkstyle-disable-line ClassDataAbstractionCouplin
             case "any_match":
                 final String field = resolvedAttribute(p, 1);
                 final String value = resolvedAttribute(p, 2);
-                System.out.printf("<any_match>: field: %s value: %s\n", field, value);
-                // TODO: get all fields named <field>, test if any matches <value>
-                return true;
+                final Multimap<String, String> map = metafix.getCurrentRecord();
+                System.out.printf("<any_match>: field: %s value: %s in: %s\n", field, value, map);
+                return map.containsKey(field) && map.get(field).stream().anyMatch(v -> v.matches(value));
             default:
                 return false;
         }

--- a/org.metafacture.fix/src/main/java/org/metafacture/metamorph/Metafix.java
+++ b/org.metafacture.fix/src/main/java/org/metafacture/metamorph/Metafix.java
@@ -75,7 +75,7 @@ import java.util.Map;
  * @author Christoph Böhme (Metamorph)
  * @author Fabian Steeg (Metafix)
  */
-
+// TODO: implement ConditionAware to support top-level `if` like in MetafixRecordTest
 public class Metafix implements StreamPipe<StreamReceiver>, NamedValuePipe, Maps { // checkstyle-disable-line ClassDataAbstractionCoupling|ClassFanOutComplexity
 
     public static final String ELSE_KEYWORD = "_else";
@@ -541,6 +541,10 @@ public class Metafix implements StreamPipe<StreamReceiver>, NamedValuePipe, Maps
 
     public void setRecordMode(final boolean recordMode) {
         this.recordMode = recordMode;
+    }
+
+    public boolean isRecordMode() {
+        return recordMode;
     }
 
 }

--- a/org.metafacture.fix/src/main/java/org/metafacture/metamorph/Metafix.java
+++ b/org.metafacture.fix/src/main/java/org/metafacture/metamorph/Metafix.java
@@ -381,6 +381,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, NamedValuePipe, Maps
     }
 
     private void send(final String key, final String value, final List<NamedValueReceiver> dataList) {
+        System.out.printf("Sending '%s':'%s' to %s\n", key, value, dataList);
         for (final NamedValueReceiver data : dataList) {
             data.receive(key, value, null, recordCount, currentEntityCount);
         }

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixDslTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixDslTest.java
@@ -926,6 +926,7 @@ public class MetafixDslTest {
                 "  add_field('type', 'Organization')", //
                 "end");
 
+        metafix.setRecordMode(true);
         final String name = "name";
 
         metafix.startRecord("1");
@@ -934,21 +935,12 @@ public class MetafixDslTest {
 
         metafix.startRecord("2");
         metafix.literal(name, "Some University");
+        metafix.literal(name, "Filibandrina");
         metafix.endRecord();
 
         Assert.assertTrue("Some University".matches(".*University.*"));
-
         final InOrder ordered = Mockito.inOrder(streamReceiver);
-
-        ordered.verify(streamReceiver).startRecord("1");
-        ordered.verify(streamReceiver, Mockito.never()).literal("type", "Organization");
-        ordered.verify(streamReceiver).endRecord();
-
-        ordered.verify(streamReceiver).startRecord("2");
-        ordered.verify(streamReceiver).literal("type", "Organization");
-        ordered.verify(streamReceiver).endRecord();
-
-        ordered.verifyNoMoreInteractions();
+        ordered.verify(streamReceiver, Mockito.times(1)).literal("type", "Organization");
     }
 
     @Test

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixDslTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixDslTest.java
@@ -380,7 +380,6 @@ public class MetafixDslTest {
     public void prependLiteralWithVarVal() {
         final Metafix metafix = fix(
                 ImmutableMap.of("pre", "eha"),
-                streamReceiver,
                 "do map(a)",
                 "  compose(prefix: '$[pre]')",
                 "end"
@@ -400,7 +399,6 @@ public class MetafixDslTest {
     public void prependLiteralWithVarKey() {
         final Metafix metafix = fix(
                 ImmutableMap.of("composeOperation", "prefix"),
-                streamReceiver,
                 "do map(a)",
                 "  compose('$[composeOperation]': 'eha')",
                 "end"
@@ -936,17 +934,17 @@ public class MetafixDslTest {
     }
 
     private Metafix fix(final String... fix) {
-        return fix(Collections.emptyMap(), streamReceiver, fix);
+        return fix(Collections.emptyMap(), fix);
     }
 
-    static Metafix fix(final Map<String, String> vars, final StreamReceiver receiver, final String... fix) {
+    private Metafix fix(final Map<String, String> vars, final String... fix) {
         final String fixString = String.join("\n", fix);
         System.out.println("\nFix string: " + fixString);
 
         Metafix metafix = null;
         try {
             metafix = new Metafix(fixString, vars);
-            metafix.setReceiver(receiver);
+            metafix.setReceiver(streamReceiver);
         }
         catch (final FileNotFoundException e) {
             e.printStackTrace();

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixIfTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixIfTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 Fabian Steeg, hbz
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.metamorph;
+
+import org.metafacture.framework.StreamReceiver;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+
+/**
+ * Tests the `if` Metamorph mechanism adapted for Metafix via DSL.
+ *
+ * See https://github.com/metafacture/metafacture-fix/issues/10
+ *
+ * @author Fabian Steeg
+ */
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public class MetafixIfTest {
+
+    @RegisterExtension
+    private MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private StreamReceiver streamReceiver;
+
+    public MetafixIfTest() {
+    }
+
+    @Test
+    public void ifInCollectorEquals() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "do combine(name: 'fullName', value: '${first} ${last}')", //
+                " if equals('author.type', 'Person')", //
+                "  map('author.first', 'first')", //
+                "  map('author.last', 'last')", //
+                " end", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.startEntity("author");
+                i.literal("first", "Max");
+                i.literal("last", "Musterman");
+                i.literal("type", "Person");
+                i.endEntity();
+                i.endRecord();
+                //
+                i.startRecord("2");
+                i.startEntity("author");
+                i.literal("type", "Organization");
+                i.endEntity();
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("fullName", "Max Musterman");
+                o.get().endRecord();
+                //
+                o.get().startRecord("2");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void ifInCollectorContains() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "do combine(name: 'fullName', value: '${first} ${last}')", //
+                " if contains('author.type', 'Person')", //
+                "  map('author.first', 'first')", //
+                "  map('author.last', 'last')", //
+                " end", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.startEntity("author");
+                i.literal("type", "Organization");
+                i.endEntity();
+                i.endRecord();
+                //
+                i.startRecord("2");
+                i.startEntity("author");
+                i.literal("first", "Max");
+                i.literal("last", "Musterman");
+                i.literal("type", "DifferentiatedPerson");
+                i.endEntity();
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().endRecord();
+                //
+                o.get().startRecord("2");
+                o.get().literal("fullName", "Max Musterman");
+                o.get().endRecord();
+            });
+    }
+}

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixIfTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixIfTest.java
@@ -18,6 +18,7 @@ package org.metafacture.metamorph;
 
 import org.metafacture.framework.StreamReceiver;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -49,31 +50,208 @@ public class MetafixIfTest {
     }
 
     @Test
-    public void ifInCollectorEquals() {
+    public void ifTopLevel() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
-                "do combine(name: 'fullName', value: '${first} ${last}')", //
-                " if equals('author.type', 'Person')", //
-                "  map('author.first', 'first')", //
-                "  map('author.last', 'last')", //
+                "map('name')",
+                "if contains('name', 'University')", //
+                "  add_field('type', 'Organization')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "A University");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "A University");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void ifTopLevelWithEqualsFunction() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "if equals('name', 'University')", //
+                "  add_field('type', 'Organization')", //
+                "end", //
+                "map('name')"),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "University");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "University");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void ifInCollector() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "do entity('author')",
+                " map('name')",
+                " if contains('name', 'University')", //
+                "  add_field('type', 'Organization')", //
+                " end",
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "A University");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("author");
+                o.get().literal("type", "Organization");
+                o.get().literal("name", "A University");
+                o.get().endEntity();
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void ifTopLevelMultiRecords() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "map('name')",
+                "if contains('name', 'University')", //
+                "  add_field('type', 'Organization')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Max");
+                i.endRecord();
+                i.startRecord("2");
+                i.literal("name", "A University");
+                i.endRecord();
+                i.startRecord("3");
+                i.literal("name", "Mary");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "Max");
+                o.get().endRecord();
+                o.get().startRecord("2");
+                o.get().literal("name", "A University");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+                o.get().startRecord("3");
+                o.get().literal("name", "Mary");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void ifTopLevelMultiRecordsMapField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "if contains('name', 'University')", //
+                "  map('name', 'orgName')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Max");
+                i.endRecord();
+                i.startRecord("2");
+                i.literal("name", "A University");
+                i.endRecord();
+                i.startRecord("3");
+                i.literal("name", "Mary");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().endRecord();
+                o.get().startRecord("2");
+                o.get().literal("orgName", "A University");
+                o.get().endRecord();
+                o.get().startRecord("3");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    @Disabled // TODO: in collector, `map` not firing when `if` fails
+    public void ifInCollectorMultiRecords() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "do entity('author')",
+                " map('name')",
+                " if contains('name', 'University')", //
+                "  add_field('type', 'Organization')", //
+                " end",
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Max");
+                i.endRecord();
+                i.startRecord("2");
+                i.literal("name", "A University");
+                i.endRecord();
+                i.startRecord("3");
+                i.literal("name", "Mary");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("author");
+                o.get().literal("name", "Max");
+                o.get().endEntity();
+                o.get().endRecord();
+                o.get().startRecord("2");
+                o.get().startEntity("author");
+                o.get().literal("type", "Organization");
+                o.get().literal("name", "A University");
+                o.get().endEntity();
+                o.get().endRecord();
+                o.get().startRecord("3");
+                o.get().startEntity("author");
+                o.get().literal("name", "Mary");
+                o.get().endEntity();
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    // Without `entity`, but nested.entity.syntax: two entities, same name
+    public void mapAndTestNestedTwoEntities() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "map('name', 'author.name')",
+                "if contains('name', 'University')", //
+                " add_field('author.type', 'Organization')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "A University");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("author");
+                o.get().literal("type", "Organization");
+                o.get().endEntity();
+                o.get().startEntity("author");
+                o.get().literal("name", "A University");
+                o.get().endEntity();
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    // Top-level `if` constructs internally wrap a choose collector:
+    public void ifInCollectorChoose() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "do choose(flushWith: 'record')",
+                " if contains('name', 'University')", //
+                "  add_field('type', 'Organization')", //
                 " end", //
                 "end"), //
             i -> {
                 i.startRecord("1");
-                i.startEntity("author");
-                i.literal("first", "Max");
-                i.literal("last", "Musterman");
-                i.literal("type", "Person");
-                i.endEntity();
+                i.literal("name", "Max University");
                 i.endRecord();
                 //
                 i.startRecord("2");
-                i.startEntity("author");
-                i.literal("type", "Organization");
-                i.endEntity();
+                i.literal("name", "Max Musterman");
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().literal("fullName", "Max Musterman");
+                o.get().literal("type", "Organization");
                 o.get().endRecord();
                 //
                 o.get().startRecord("2");
@@ -82,7 +260,7 @@ public class MetafixIfTest {
     }
 
     @Test
-    public void ifInCollectorContains() {
+    public void ifInCollectorCombine() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
                 "do combine(name: 'fullName', value: '${first} ${last}')", //
                 " if contains('author.type', 'Person')", //
@@ -113,4 +291,27 @@ public class MetafixIfTest {
                 o.get().endRecord();
             });
     }
+
+    @Test
+    @Disabled // TODO: second `add_field` not firing
+    public void ifTopLevelMultipleAddField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "map('name')",
+                "if contains('name', 'University')", //
+                "  add_field('type', 'Organization')", //
+                "  add_field('comment', 'type was guessed')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "A University");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "A University");
+                o.get().literal("type", "Organization");
+                o.get().literal("comment", "type was guessed");
+                o.get().endRecord();
+            });
+    }
+
 }

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
  */
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("checkstyle:MultipleStringLiterals")
+@Disabled // Temporarily disabled while working on adapting `if` from metamorph
 public class MetafixRecordTest {
 
     @RegisterExtension

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
@@ -64,14 +64,12 @@ public class MetafixRecordTest {
                 i.literal(name, "Filibandrina");
                 i.endRecord();
             }, o -> {
-                // TODO: fix event order
                 o.get().startRecord("1");
                 o.get().endRecord();
-                o.get().startRecord("1");
-                o.get().startRecord("2");
-                o.get().endRecord();
+                //
                 o.get().startRecord("2");
                 o.get().literal("type", "Organization");
+                o.get().endRecord();
             });
     }
 
@@ -93,14 +91,12 @@ public class MetafixRecordTest {
                 i.literal(name, "University Filibandrina");
                 i.endRecord();
             }, o -> {
-                // TODO: fix event order
                 o.get().startRecord("1");
                 o.get().endRecord();
-                o.get().startRecord("1");
-                o.get().startRecord("2");
-                o.get().endRecord();
+                //
                 o.get().startRecord("2");
                 o.get().literal("type", "Organization");
+                o.get().endRecord();
             });
     }
 

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Fabian Steeg, hbz
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.metamorph;
+
+import org.metafacture.framework.StreamReceiver;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+/**
+ * Tests the non-field-streaming record functionality of Metafix via DSL.
+ *
+ * See https://github.com/metafacture/metafacture-fix/issues/35
+ *
+ * @author Fabian Steeg
+ */
+@ExtendWith(MockitoExtension.class)
+public class MetafixRecordTest {
+
+    @RegisterExtension
+    private MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private StreamReceiver streamReceiver;
+
+    public MetafixRecordTest() {
+    }
+
+    @Test
+    public void shouldSupportLookingAtOtherFieldsAny() {
+        final Metafix metafix = fix(//
+                "if any_match('name', '.*University.*')", //
+                "  add_field('type', 'Organization')", //
+                "end");
+
+        metafix.setRecordMode(true);
+        final String name = "name";
+
+        metafix.startRecord("1");
+        metafix.literal(name, "Max Musterman");
+        metafix.endRecord();
+
+        metafix.startRecord("2");
+        metafix.literal(name, "Some University");
+        metafix.literal(name, "Filibandrina");
+        metafix.endRecord();
+
+        Assert.assertTrue("Some University".matches(".*University.*"));
+        final InOrder ordered = Mockito.inOrder(streamReceiver);
+        ordered.verify(streamReceiver, Mockito.times(1)).literal("type", "Organization");
+    }
+
+    @Test
+    public void shouldSupportLookingAtOtherFieldsAll() {
+        final Metafix metafix = fix(//
+                "if all_match('name', '.*University.*')", //
+                "  add_field('type', 'Organization')", //
+                "end");
+
+        metafix.setRecordMode(true);
+        final String name = "name";
+
+        metafix.startRecord("1");
+        metafix.literal(name, "Max Musterman");
+        metafix.literal(name, "A University");
+        metafix.endRecord();
+
+        metafix.startRecord("2");
+        metafix.literal(name, "A University");
+        metafix.literal(name, "University Filibandrina");
+        metafix.endRecord();
+
+        final InOrder ordered = Mockito.inOrder(streamReceiver);
+        ordered.verify(streamReceiver, Mockito.times(1)).literal("type", "Organization");
+    }
+
+    private Metafix fix(final String... fix) {
+        return MetafixDslTest.fix(Collections.emptyMap(), streamReceiver, fix);
+    }
+
+}

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixRecordTest.java
@@ -18,6 +18,7 @@ package org.metafacture.metamorph;
 
 import org.metafacture.framework.StreamReceiver;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -36,6 +37,7 @@ import java.util.Arrays;
  * @author Fabian Steeg
  */
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
 public class MetafixRecordTest {
 
     @RegisterExtension
@@ -48,20 +50,19 @@ public class MetafixRecordTest {
     }
 
     @Test
-    public void shouldSupportLookingAtOtherFieldsAny() {
-        final String name = "name";
+    public void ifAnyMatch() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
                 "if any_match('name', '.*University.*')", //
                 "  add_field('type', 'Organization')", //
                 "end"), //
             i -> {
                 i.startRecord("1");
-                i.literal(name, "Max Musterman");
+                i.literal("name", "Max Musterman");
                 i.endRecord();
                 //
                 i.startRecord("2");
-                i.literal(name, "Some University");
-                i.literal(name, "Filibandrina");
+                i.literal("name", "Some University");
+                i.literal("name", "Filibandrina");
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
@@ -74,21 +75,20 @@ public class MetafixRecordTest {
     }
 
     @Test
-    public void shouldSupportLookingAtOtherFieldsAll() {
-        final String name = "name";
+    public void ifAllMatch() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
                 "if all_match('name', '.*University.*')", //
                 "  add_field('type', 'Organization')", //
                 "end"), //
             i -> {
                 i.startRecord("1");
-                i.literal(name, "Max Musterman");
-                i.literal(name, "A University");
+                i.literal("name", "Max Musterman");
+                i.literal("name", "A University");
                 i.endRecord();
                 //
                 i.startRecord("2");
-                i.literal(name, "Some University");
-                i.literal(name, "University Filibandrina");
+                i.literal("name", "Some University");
+                i.literal("name", "University Filibandrina");
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
@@ -100,4 +100,128 @@ public class MetafixRecordTest {
             });
     }
 
+    @Test
+    public void ifAnyMatchNested() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "if any_match('author.name.label', '.*University.*')", //
+                "  add_field('author.type', 'Organization')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.startEntity("author");
+                i.startEntity("name");
+                i.literal("label", "Max Musterman");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+                //
+                i.startRecord("2");
+                i.startEntity("author");
+                i.startEntity("name");
+                i.literal("label", "Some University");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().endRecord();
+                //
+                o.get().startRecord("2");
+                o.get().startEntity("author");
+                o.get().literal("type", "Organization");
+                o.get().endEntity();
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    @Disabled // TODO: fix events for this record order
+    public void ifAnyMatchFirst() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "if any_match('name', '.*University.*')", //
+                "  add_field('type', 'Organization')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Some University");
+                i.endRecord();
+                //
+                i.startRecord("2");
+                i.literal("name", "Max Musterman");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+                //
+                o.get().startRecord("2");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    @Disabled // TODO: support else block
+    public void ifAnyMatchElse() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "if any_match('name', '.*University.*')", //
+                "  add_field('type', 'Organization')", //
+                "else", //
+                "  add_field('type', 'Person')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Max Musterman");
+                i.endRecord();
+                //
+                i.startRecord("2");
+                i.literal("name", "Some University");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("type", "Person");
+                o.get().endRecord();
+                //
+                o.get().startRecord("2");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    @Disabled // TODO: support elsif block
+    public void ifAnyMatchElsif() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(//
+                "if any_match('name', '.*University.*')", //
+                "  add_field('type', 'Organization')", //
+                "elsif any_match('name', '[^ ]* [^ ]*')", //
+                "  add_field('type', 'Person')", //
+                "else", //
+                "  add_field('type', 'Unknown')", //
+                "end"), //
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Max Musterman");
+                i.endRecord();
+                //
+                i.startRecord("2");
+                i.literal("name", "Some University");
+                i.endRecord();
+                //
+                i.startRecord("3");
+                i.literal("name", "Filibandrina");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("type", "Person");
+                o.get().endRecord();
+                //
+                o.get().startRecord("2");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+                //
+                o.get().startRecord("3");
+                o.get().literal("type", "Unknown");
+                o.get().endRecord();
+            });
+    }
 }

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixTestHelpers.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixTestHelpers.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.metamorph;
+
+import org.metafacture.framework.StreamReceiver;
+
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoAssertionError;
+
+import java.io.FileNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+/**
+ * Helper functions for Metafix tests.
+ *
+ * @author Jens Wille (metamorph.TestHelpers)
+ * @author Fabian Steeg (MetafixTestHelpers)
+ */
+public final class MetafixTestHelpers {
+
+    private MetafixTestHelpers() { }
+
+    public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Consumer<Metafix> in,
+            final Consumer<Supplier<StreamReceiver>> out) {
+        assertFix(receiver, fixDef, in, (s, f) -> out.accept(s));
+    }
+
+    public static void assertFix(final StreamReceiver receiver, final List<String> fixLines, final Consumer<Metafix> in,
+            final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out) {
+        final String fixString = String.join("\n", fixLines);
+        final Metafix metafix = fix(receiver, fixString);
+        final InOrder ordered = Mockito.inOrder(receiver);
+        try {
+            in.accept(metafix);
+            out.accept(() -> ordered.verify(receiver), i -> ordered.verify(receiver, Mockito.times(i)));
+            ordered.verifyNoMoreInteractions();
+            Mockito.verifyNoMoreInteractions(receiver);
+        }
+        catch (final MockitoAssertionError e) {
+            System.out.println(Mockito.mockingDetails(receiver).printInvocations());
+            throw e;
+        }
+    }
+
+    static Metafix fix(final StreamReceiver receiver, final String fix) {
+        System.out.println("\nFix string: " + fix);
+        Metafix metafix = null;
+        try {
+            metafix = new Metafix(fix, Collections.emptyMap());
+            metafix.setReceiver(receiver);
+        }
+        catch (final FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        metafix.setRecordMode(true);
+        return metafix;
+    }
+
+}

--- a/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixTestHelpers.java
+++ b/org.metafacture.fix/src/test/java/org/metafacture/metamorph/MetafixTestHelpers.java
@@ -72,7 +72,6 @@ public final class MetafixTestHelpers {
         catch (final FileNotFoundException e) {
             e.printStackTrace();
         }
-        metafix.setRecordMode(true);
         return metafix;
     }
 


### PR DESCRIPTION
This contains work in progress for #10 (Fix conditionals based on the Morph `<if>` construct, enabled, see `MetafixIfTest`) and #35 (record mode, disabled, see `MetafixRecordTest`).

Since metafacture-fix is work in progress in general, and this adds working if-statements for some use cases, as well as some project setup improvements (in particular for writing tests), I suggest we merge this into our main branch.