### PR TITLE
Rename destination folder for deploying IDE extensions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,6 @@ jobs:
         source_file: 'org.metafacture.fix.vsc/fix.vsix'
         destination_repo: 'metafacture/metafacture.github.io'
         destination_branch: main
-        destination_folder: 'extensions'
+        destination_folder: 'ide-extensions'
         user_email: '${{ github.actor }}@users.noreply.github.com'
         user_name: '${{ github.actor }}'


### PR DESCRIPTION
Necessary because of renaming in metafacture/metafacture.github.io, see https://github.com/metafacture/metafacture.github.io/issues/13