### PR TITLE
Upgrade Gradle wrapper to version 7.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,12 +52,12 @@ subprojects {
   targetCompatibility = '1.8'
 
   repositories {
-    jcenter()
+    mavenCentral()
     maven githubPackage.invoke("metafacture")
   }
 
   dependencies {
-    compile platform("org.eclipse.xtext:xtext-dev-bom:${versions.xtext}")
+    implementation platform("org.eclipse.xtext:xtext-dev-bom:${versions.xtext}")
   }
 
   configurations.all {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionSha256Sum=f581709a9c35e9cb92e16f585d2c4bc99b2b1a5f85d2badbd3dc6bff59e1e6dd
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/org.metafacture.fix.ide/build.gradle
+++ b/org.metafacture.fix.ide/build.gradle
@@ -3,10 +3,10 @@ plugins {
 }
 
 dependencies {
-  compile project(':metafacture-fix')
+  implementation project(':metafacture-fix')
 
-  compile "org.eclipse.xtext:org.eclipse.xtext.ide:${versions.xtext}"
-  compile "org.eclipse.xtext:org.eclipse.xtext.xbase.ide:${versions.xtext}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext.ide:${versions.xtext}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext.xbase.ide:${versions.xtext}"
 }
 
 apply plugin: 'application'
@@ -17,7 +17,7 @@ applicationName = 'xtext-server'
 
 shadowJar {
   from(project.convention.getPlugin(JavaPluginConvention).sourceSets.main.output)
-  configurations = [project.configurations.runtime]
+  configurations = [project.configurations.runtimeOnly]
 
   exclude(
     '*.html',

--- a/org.metafacture.fix.web/build.gradle
+++ b/org.metafacture.fix.web/build.gradle
@@ -3,15 +3,15 @@ plugins {
 }
 
 dependencies {
-  compile project(':metafacture-fix')
-  compile project(':org.metafacture.fix.ide')
+  implementation project(':metafacture-fix')
+  implementation project(':org.metafacture.fix.ide')
 
-  compile "org.eclipse.xtend:org.eclipse.xtend.lib:${versions.xtext}"
-  compile "org.eclipse.xtext:org.eclipse.xtext.web.servlet:${versions.xtext}"
-  compile "org.eclipse.xtext:org.eclipse.xtext.xbase.web:${versions.xtext}"
-  compile "org.webjars:ace:${versions.ace}"
-  compile "org.webjars:jquery:${versions.jquery}"
-  compile "org.webjars:requirejs:${versions.requirejs}"
+  implementation "org.eclipse.xtend:org.eclipse.xtend.lib:${versions.xtext}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext.web.servlet:${versions.xtext}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext.xbase.web:${versions.xtext}"
+  implementation "org.webjars:ace:${versions.ace}"
+  implementation "org.webjars:jquery:${versions.jquery}"
+  implementation "org.webjars:requirejs:${versions.requirejs}"
 
   providedCompile "org.eclipse.jetty:jetty-annotations:${versions.jetty}"
   providedCompile "org.slf4j:slf4j-simple:${versions.slf4j}"
@@ -27,7 +27,7 @@ dependencies {
 task jettyRun(type: JavaExec) {
   dependsOn(sourceSets.main.runtimeClasspath)
   classpath = sourceSets.main.runtimeClasspath.filter { it.exists() }
-  main = 'org.metafacture.metafix.web.ServerLauncher'
+  mainClass = 'org.metafacture.metafix.web.ServerLauncher'
   standardInput = System.in
   group = 'run'
   description = 'Starts an example Jetty server with your language'

--- a/org.metafacture.fix/build.gradle
+++ b/org.metafacture.fix/build.gradle
@@ -1,19 +1,19 @@
 plugins {
   id 'com.adarshr.test-logger' version '1.7.0'
-  id 'maven'
+  id 'maven-publish'
 }
 
 dependencies {
-  compile "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
-  compile "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
-  compile "com.google.guava:guava:${versions.guava}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
+  implementation "com.google.guava:guava:${versions.guava}"
 
-  testCompile "org.junit.jupiter:junit-jupiter-api:${versions.junit_jupiter}"
-  testCompile "org.junit.platform:junit-platform-launcher:${versions.junit_platform}"
-  testCompile "org.eclipse.xtext:org.eclipse.xtext.testing:${versions.xtext}"
-  testCompile "org.eclipse.xtext:org.eclipse.xtext.xbase.testing:${versions.xtext}"
+  testImplementation "org.junit.jupiter:junit-jupiter-api:${versions.junit_jupiter}"
+  testImplementation "org.junit.platform:junit-platform-launcher:${versions.junit_platform}"
+  testImplementation "org.eclipse.xtext:org.eclipse.xtext.testing:${versions.xtext}"
+  testImplementation "org.eclipse.xtext:org.eclipse.xtext.xbase.testing:${versions.xtext}"
 
-  testRuntime "org.junit.jupiter:junit-jupiter-engine:${versions.junit_jupiter}"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${versions.junit_jupiter}"
 
   implementation "org.metafacture:metafacture-commons:${versions.metafacture}"
   implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"
@@ -27,7 +27,7 @@ dependencies {
 
 configurations {
   mwe2 {
-    extendsFrom compile
+    extendsFrom implementation
   }
 }
 
@@ -42,16 +42,21 @@ test {
   useJUnitPlatform()
 }
 
+task install(dependsOn: publishToMavenLocal,
+    description: "Installs the 'archives' artifacts into the local Maven repository. [deprecated]") {
+  doFirst { println "This task is deprecated; use 'publishToMavenLocal' instead." }
+}
+
 def xtextFile = 'src/main/java/org/metafacture/metafix/Fix.xtext'
 
 task validateXtextLanguage(type: JavaExec) {
-  main = 'org.metafacture.metafix.validation.XtextValidator'
+  mainClass = 'org.metafacture.metafix.validation.XtextValidator'
   classpath = sourceSets.main.runtimeClasspath
   args += xtextFile
 }
 
 task generateXtextLanguage(type: JavaExec) {
-  main = 'org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher'
+  mainClass = 'org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher'
   classpath = configurations.mwe2
   inputs.file 'src/main/java/org/metafacture/metafix/GenerateFix.mwe2'
   inputs.file xtextFile
@@ -61,6 +66,7 @@ task generateXtextLanguage(type: JavaExec) {
   args += "rootPath=/${projectDir}/.."
 }
 
+processResources.dependsOn(generateXtextLanguage)
 generateXtext.dependsOn(generateXtextLanguage)
 compileJava.dependsOn(generateXtextLanguage)
 clean.dependsOn(cleanGenerateXtextLanguage)


### PR DESCRIPTION
Changes:

- `compile` -> `implementation`, `testCompile` -> `testImplementation`, `testRuntime` -> `testRuntimeOnly`: "Could not find method compile()/testCompile()/testRuntime() for arguments [...] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler."
- `runtime` -> `runtimeOnly`: "Could not get unknown property 'runtime' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer."
- `jcenter` -> `mavenCentral`: "The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.2/userguide/upgrading_version_6.html#jcenter_deprecation"
- `main` -> `mainClass`: "The JavaExec.main property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. See https://docs.gradle.org/7.2/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main for more details."
- `processResources.dependsOn(generateXtextLanguage)`: "Gradle detected a problem with the following location: '.../org.metafacture.fix/src/main/xtext-gen'. Reason: Task ':metafacture-fix:metafacture-fix:processResources' uses this output of task ':metafacture-fix:metafacture-fix:generateXtextLanguage' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency for more details about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.2/userguide/more_about_tasks.html#sec:up_to_date_checks for more details."
- `maven` (legacy) -> `maven-publish` (+ compatibility task¹): "Plugin [id: 'maven'] was not found in any of the following sources: [...]"

Remaining issue (deprecation):

- `:editorconfigCheck`: "The WorkerExecutor.submit() method has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the noIsolation(), classLoaderIsolation() or processIsolation() method instead. See https://docs.gradle.org/7.2/userguide/upgrading_version_5.html#method_workerexecutor_submit_is_deprecated for more details." (see editorconfig-gradle-plugin#15)

¹ This compatibility task might be dispensable; it seems to be used in [oersi-etl](https://gitlab.com/oersi/oersi-etl/), though.