### PR TITLE
Initial logging setup.

### DIFF
--- a/org.metafacture.fix/build.gradle
+++ b/org.metafacture.fix/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
   compile "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
   compile "com.google.guava:guava:${versions.guava}"
+  compile "org.slf4j:slf4j-api:${versions.slf4j}"
 
   testCompile "org.junit.jupiter:junit-jupiter-api:${versions.junit_jupiter}"
   testCompile "org.junit.platform:junit-platform-launcher:${versions.junit_platform}"
@@ -14,6 +15,7 @@ dependencies {
   testCompile "org.eclipse.xtext:org.eclipse.xtext.xbase.testing:${versions.xtext}"
 
   testRuntime "org.junit.jupiter:junit-jupiter-engine:${versions.junit_jupiter}"
+  testRuntime "org.slf4j:slf4j-simple:${versions.slf4j}"
 
   implementation "org.metafacture:metafacture-commons:${versions.metafacture}"
   implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"


### PR DESCRIPTION
This is just a minimal replacement for the previous print statements.

I also tried to control the log output from Xtext (`:metafacture-fix:generateXtextLanguage`), but got nowhere...

```
0    [main] INFO  text.xtext.generator.XtextGenerator  - Initializing Xtext generator
6    [main] INFO  lipse.emf.mwe.utils.StandaloneSetup  - Adding generated EPackage 'org.eclipse.xtext.common.types.TypesPackage'
64   [main] INFO  lipse.emf.mwe.utils.StandaloneSetup  - Registering project org.metafacture.fix at 'file:/[...]/metafacture-fix/org.metafacture.fix/'
65   [main] INFO  lipse.emf.mwe.utils.StandaloneSetup  - Registering project org.metafacture.fix at 'file:/[...]/metafacture-fix/org.metafacture.fix/'
65   [main] INFO  lipse.emf.mwe.utils.StandaloneSetup  - Registering project org.metafacture.fix.ide at 'file:/[...]/metafacture-fix/org.metafacture.fix.ide/'
65   [main] INFO  lipse.emf.mwe.utils.StandaloneSetup  - Registering project org.metafacture.fix.web at 'file:/[...]/metafacture-fix/org.metafacture.fix.web/'
72   [main] INFO  lipse.emf.mwe.utils.StandaloneSetup  - Using resourceSet registry. The registered Packages will not be registered in the global EPackage.Registry.INSTANCE!
253  [main] INFO  clipse.emf.mwe.utils.GenModelHelper  - Registered GenModel 'http://www.eclipse.org/Xtext/Xbase/XAnnotations' from 'platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel'
256  [main] INFO  clipse.emf.mwe.utils.GenModelHelper  - Registered GenModel 'http://www.eclipse.org/xtext/xbase/Xtype' from 'platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel'
268  [main] INFO  clipse.emf.mwe.utils.GenModelHelper  - Registered GenModel 'http://www.eclipse.org/xtext/xbase/Xbase' from 'platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel'
268  [main] INFO  clipse.emf.mwe.utils.GenModelHelper  - Registered GenModel 'http://www.eclipse.org/xtext/common/JavaVMTypes' from 'platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.genmodel'
704  [main] INFO  text.xtext.generator.XtextGenerator  - Generating org.metafacture.metafix.Fix
2264 [main] INFO  nerator.ecore.EMFGeneratorFragment2  - Generating EMF model code
2285 [main] INFO  clipse.emf.mwe.utils.GenModelHelper  - Registered GenModel 'http://www.metafacture.org/metafix/Fix' from 'platform:/resource/org.metafacture.fix/model/generated/Fix.genmodel'
8921 [main] INFO  text.xtext.generator.XtextGenerator  - Generating common infrastructure
8922 [main] INFO  .emf.mwe2.runtime.workflow.Workflow  - Done.
```