### PR TITLE
Handle and access repeated fields as arrays

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixPredicate.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixPredicate.java
@@ -31,7 +31,7 @@ enum FixPredicate {
     equal {
         @Override
         public Predicate<Value> of(final String string) {
-            return v ->  v.toString().equals(string);
+            return v -> v.toString().equals(string);
         }
     },
     match {

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -182,21 +182,9 @@ public class Metafix implements StreamPipe<StreamReceiver> {
                 entities.size() <= currentEntityIndex ? null : entities.get(currentEntityIndex);
         entityCountStack.push(Integer.valueOf(entityCount));
         flattener.startEntity(name);
-        entities.add(currentEntity(name, previousEntity != null ? previousEntity : currentRecord));
-    }
-
-    private Value.Hash currentEntity(final String name, final Value.Hash previousEntity) {
-        final Value existingValue = previousEntity != null ? previousEntity.get(name) : null;
-        final Value.Hash currentEntity;
-        if (existingValue != null && existingValue.isHash()) {
-            currentEntity = previousEntity.get(name).asHash();
-        }
-        else {
-            final Value value = Value.newHash();
-            currentEntity = value.asHash();
-            (previousEntity != null ? previousEntity : currentRecord).add(name, value);
-        }
-        return currentEntity;
+        final Value value = Value.newHash();
+        (previousEntity != null ? previousEntity : currentRecord).add(name, value);
+        entities.add(value.asHash());
     }
 
     @Override

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -149,7 +149,7 @@ public class Metafix implements StreamPipe<StreamReceiver> {
         Value.asList(value, array -> {
             final boolean isMulti = array.size() > 1 || value.isArray();
             if (isMulti) {
-                outputStreamReceiver.startEntity(field + "[]");
+                outputStreamReceiver.startEntity(field);
             }
 
             for (int i = 0; i < array.size(); ++i) {

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -156,7 +156,7 @@ public class Metafix implements StreamPipe<StreamReceiver> {
                 final Value arrayValue = array.get(i);
 
                 if (arrayValue.isHash()) {
-                    outputStreamReceiver.startEntity(isMulti ? "" : field);
+                    outputStreamReceiver.startEntity(isMulti ? (i + 1) + "" : field);
                     arrayValue.asHash().forEach(this::emit);
                     outputStreamReceiver.endEntity();
                 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -117,11 +117,11 @@ public class MetafixBindTest {
             }, (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author[]");
-                o.get().startEntity("");
+                o.get().startEntity("1");
                 o.get().literal("name", "A University");
                 // o.get().literal("type", "Default"); // FIXME: bind scope broken
                 o.get().endEntity();
-                o.get().startEntity("");
+                o.get().startEntity("2");
                 o.get().literal("name", "Max");
                 o.get().literal("type", "Default");
                 f.apply(2).endEntity();
@@ -182,11 +182,11 @@ public class MetafixBindTest {
             }, (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author[]");
-                o.get().startEntity("");
+                o.get().startEntity("1");
                 o.get().literal("name", "A University");
                 o.get().literal("type", "Organization");
                 o.get().endEntity();
-                o.get().startEntity("");
+                o.get().startEntity("2");
                 o.get().literal("name", "Max");
                 o.get().literal("type", "Person");
                 f.apply(2).endEntity();

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -62,7 +62,7 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("author[]");
+                o.get().startEntity("author");
                 o.get().literal("1", "A UNIVERSITY");
                 o.get().literal("2", "MAX");
                 o.get().endEntity();
@@ -88,7 +88,7 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("author[]");
+                o.get().startEntity("author");
                 o.get().literal("1", "A UNIVERSITY");
                 o.get().literal("2", "MAX");
                 o.get().endEntity();
@@ -100,9 +100,9 @@ public class MetafixBindTest {
     public void doListWithAppendAndLast() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do list('path': 'creator', 'var': 'c')",
-                " set_array('author')",
-                " copy_field('c.name', 'author.$append.name')",
-                " add_field('author.$last.type', 'Default')",
+                " set_array('author[]')",
+                " copy_field('c.name', 'author[].$append.name')",
+                " add_field('author[].$last.type', 'Default')",
                 "end",
                 "remove_field('creator')"),
             i -> {
@@ -149,7 +149,7 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("author[]");
+                o.get().startEntity("author");
                 o.get().literal("1", "A UNIVERSITY");
                 o.get().literal("2", "MAX");
                 o.get().endEntity();
@@ -161,12 +161,12 @@ public class MetafixBindTest {
     public void doListEntitesToEntities() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do list('path': 'creator.name', 'var': 'c')",
-                " set_array('author')",
-                " copy_field('c', 'author.$append.name')",
+                " set_array('author[]')",
+                " copy_field('c', 'author[].$append.name')",
                 " if all_contain('c', 'University')",
-                "  add_field('author.$last.type', 'Organization')",
+                "  add_field('author[].$last.type', 'Organization')",
                 " else",
-                "  add_field('author.$last.type', 'Person')", //",
+                "  add_field('author[].$last.type', 'Person')", //",
                 " end",
                 "end",
                 "remove_field('creator')"),

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -66,7 +66,7 @@ public class MetafixIfTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Mary");
                 o.get().literal("2", "A University");
                 o.get().endEntity();
@@ -74,7 +74,7 @@ public class MetafixIfTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Mary");
                 o.get().literal("2", "Max");
                 o.get().endEntity();
@@ -106,14 +106,14 @@ public class MetafixIfTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Mary");
                 o.get().literal("2", "A University");
                 o.get().endEntity();
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Great University");
                 o.get().literal("2", "A University");
                 o.get().endEntity();
@@ -151,7 +151,7 @@ public class MetafixIfTest {
             }, (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Mary");
                 o.get().literal("2", "A University");
                 f.apply(2).endEntity();
@@ -159,7 +159,7 @@ public class MetafixIfTest {
 
                 o.get().startRecord("2");
                 o.get().startEntity("author");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Max");
                 o.get().literal("2", "Mary");
                 f.apply(2).endEntity();
@@ -285,7 +285,7 @@ public class MetafixIfTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Some University");
                 o.get().literal("2", "Filibandrina");
                 o.get().endEntity();
@@ -312,14 +312,14 @@ public class MetafixIfTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Max");
                 o.get().literal("2", "A University");
                 o.get().endEntity();
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "Some University");
                 o.get().literal("2", "University Filibandrina");
                 o.get().endEntity();

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -67,7 +67,7 @@ public class MetafixLookupTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "Alohaeha");
                 o.get().literal("2", "Moin zäme");
                 o.get().literal("3", "Tach");
@@ -92,7 +92,7 @@ public class MetafixLookupTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "Alohaeha");
                 o.get().literal("2", "Moin zäme");
                 o.get().endEntity();
@@ -115,7 +115,7 @@ public class MetafixLookupTest {
             }, (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("data");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "Alohaeha");
                 o.get().literal("2", "Moin zäme");
                 o.get().literal("3", "Tach");
@@ -146,7 +146,7 @@ public class MetafixLookupTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "Alohaeha");
                 o.get().literal("2", "Moin zäme");
                 o.get().literal("3", "Tach");
@@ -179,7 +179,7 @@ public class MetafixLookupTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "Alohaeha");
                 o.get().literal("2", "Moin zäme");
                 o.get().literal("3", "Tach");

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -70,7 +70,7 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "MARC");
                 o.get().literal("2", "JSON");
                 o.get().endEntity();
@@ -95,7 +95,7 @@ public class MetafixMethodTest {
             }, (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("data");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "MARC");
                 o.get().literal("2", "JSON");
                 f.apply(2).endEntity();
@@ -123,7 +123,7 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "marc");
                 o.get().literal("2", "json");
                 o.get().endEntity();
@@ -154,7 +154,7 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "Marc");
                 o.get().literal("2", "Json");
                 o.get().endEntity();
@@ -185,7 +185,7 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "m");
                 o.get().literal("2", "j");
                 o.get().endEntity();
@@ -217,7 +217,7 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "ma");
                 o.get().literal("2", "js");
                 o.get().endEntity();
@@ -248,7 +248,7 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("title[]");
+                o.get().startEntity("title");
                 o.get().literal("1", "marc");
                 o.get().literal("2", "json");
                 o.get().endEntity();
@@ -270,7 +270,7 @@ public class MetafixMethodTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("number[]");
+                o.get().startEntity("number");
                 o.get().literal("1", "41   : 15");
                 o.get().endEntity();
                 o.get().endRecord();
@@ -287,7 +287,7 @@ public class MetafixMethodTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("date[]");
+                o.get().startEntity("date");
                 o.get().literal("1", "2015");
                 o.get().literal("2", "03");
                 o.get().literal("3", "07");

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -129,7 +129,7 @@ public class MetafixRecordTest {
                 o.get().startRecord("1");
                 o.get().startEntity("deep");
                 o.get().startEntity("nested");
-                o.get().startEntity("field[]");
+                o.get().startEntity("field");
                 o.get().literal("1", "value1");
                 o.get().literal("2", "value2");
                 f.apply(3).endEntity();
@@ -211,7 +211,7 @@ public class MetafixRecordTest {
             }, (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("my");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "patrick");
                 o.get().literal("2", "nicolas");
                 f.apply(2).endEntity();
@@ -219,7 +219,7 @@ public class MetafixRecordTest {
 
                 o.get().startRecord("2");
                 o.get().startEntity("my");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "max");
                 o.get().literal("2", "patrick");
                 o.get().literal("3", "nicolas");
@@ -228,7 +228,7 @@ public class MetafixRecordTest {
 
                 o.get().startRecord("3");
                 o.get().startEntity("my");
-                o.get().startEntity("name[]");
+                o.get().startEntity("name");
                 o.get().literal("1", "patrick");
                 o.get().literal("2", "nicolas");
                 f.apply(2).endEntity();
@@ -306,7 +306,7 @@ public class MetafixRecordTest {
     public void copyIntoArrayOfStrings() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 // "set_array('author')", <- results in separate objects/entities here
-                "copy_field('your.name','author.name')",
+                "copy_field('your.name','author.name[]')",
                 "remove_field('your')"),
             i -> {
                 i.startRecord("1");
@@ -329,8 +329,8 @@ public class MetafixRecordTest {
     @Test
     public void copyIntoArrayOfObjects() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "set_array('author')",
-                "copy_field('your.name','author.name')",
+                "set_array('author[]')",
+                "copy_field('your.name','author[].name')",
                 "remove_field('your')"),
             i -> {
                 i.startRecord("1");
@@ -357,8 +357,8 @@ public class MetafixRecordTest {
     @Test
     public void copyIntoArrayTopLevel() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "set_array('author')",
-                "copy_field('your.name', 'author')",
+                "set_array('author[]')",
+                "copy_field('your.name', 'author[]')",
                 "remove_field('your')"),
             i -> {
                 i.startRecord("1");
@@ -467,7 +467,7 @@ public class MetafixRecordTest {
     @Test
     public void setArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "set_array('foo','a','b','c')"),
+                "set_array('foo[]','a','b','c')"),
             i -> {
                 i.startRecord("1");
                 i.endRecord();
@@ -594,7 +594,7 @@ public class MetafixRecordTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("foo[]");
+                o.get().startEntity("foo");
                 o.get().literal("1", "a");
                 o.get().literal("2", "b");
                 o.get().literal("3", "c");
@@ -625,8 +625,8 @@ public class MetafixRecordTest {
     @Test
     public void appendArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "set_array('nums', '1')",
-                "set_array('nums.$append', '2', '3')"),
+                "set_array('nums[]', '1')",
+                "set_array('nums[].$append', '2', '3')"),
             i -> {
                 i.startRecord("1");
                 i.endRecord();
@@ -644,8 +644,8 @@ public class MetafixRecordTest {
     @Test
     public void mixedArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "set_array('@context', 'https://w3id.org/kim/lrmi-profile/draft/context.jsonld')",
-                "set_hash('@context.$append', '@language': 'de')"),
+                "set_array('@context[]', 'https://w3id.org/kim/lrmi-profile/draft/context.jsonld')",
+                "set_hash('@context[].$append', '@language': 'de')"),
             i -> {
                 i.startRecord("1");
                 i.endRecord();

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -344,10 +344,10 @@ public class MetafixRecordTest {
             }, (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author[]");
-                o.get().startEntity("");
+                o.get().startEntity("1");
                 o.get().literal("name", "max");
                 o.get().endEntity();
-                o.get().startEntity("");
+                o.get().startEntity("2");
                 o.get().literal("name", "mo");
                 f.apply(2).endEntity();
                 o.get().endRecord();
@@ -653,7 +653,7 @@ public class MetafixRecordTest {
                 o.get().startRecord("1");
                 o.get().startEntity("@context[]");
                 o.get().literal("1", "https://w3id.org/kim/lrmi-profile/draft/context.jsonld");
-                o.get().startEntity("");
+                o.get().startEntity("2");
                 o.get().literal("@language", "de");
                 f.apply(2).endEntity();
                 o.get().endRecord();


### PR DESCRIPTION
Will resolve #65.

This is far from consistent and a bit messy, but hopefully some steps in the right direction. I noted some TODOs which would result in some refactoring work (mainly around avoiding switch statements by moving functionality into enum elements; as well as consistent handling of special path segments like wildcards and indexes), but to make sure we're moving into the right direction, I'd like to focus on use cases right now.

For [our OERSI use case](https://gitlab.com/oersi/oersi-etl/-/merge_requests/99) (updated for this state in [8b27e98c](https://gitlab.com/oersi/oersi-etl/-/merge_requests/99/diffs?commit_id=8b27e98ceaeb1926ddb8359697269c4d03c61b16)), this provides some progress, but I don't think a functional review makes sense at this point. For that, I'd like to continue with the bind scope issues, which are related to https://github.com/metafacture/metafacture-fix/issues/66. To avoid a larger and longer-running branch with these additional changes, I think it makes sense to review and merge the current work in progress at this point.