### PR TITLE
Add support for Metamorph wildcards.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -71,7 +71,6 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     private final Map<String, Map<String, String>> maps = new HashMap<>();
     private final StreamFlattener flattener = new StreamFlattener();
 
-    // TODO: Use SimpleRegexTrie / WildcardTrie for wildcard, alternation and character class support
     private Record currentRecord = new Record();
     private Fix fix;
     private Map<String, String> vars = new HashMap<>();

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -507,6 +507,7 @@ public class Value {
         private static final String FIELD_PATH_SEPARATOR = "\\.";
 
         private final Map<String, Value> map = new LinkedHashMap<>();
+        private final SimpleRegexTrie<String> trie = new SimpleRegexTrie<>();
 
         /**
          * Creates an empty instance of {@link Hash}.
@@ -840,9 +841,7 @@ public class Value {
         }
 
         private Predicate<String> fieldMatcher(final String pattern) {
-            final SimpleRegexTrie<String> trie = new SimpleRegexTrie<>();
             trie.put(pattern, pattern);
-
             return field -> trie.get(field).contains(pattern);
         }
 

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -16,6 +16,8 @@
 
 package org.metafacture.metafix;
 
+import org.metafacture.commons.tries.SimpleRegexTrie;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,7 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -36,6 +40,8 @@ public class Value {
     /*package-private*/ static final String APPEND_FIELD = "$append";
     private static final String LAST_FIELD = "$last";
     private static final String ASTERISK = "*";
+
+    private static final String UNEXPECTED = "expected array or hash, got ";
 
     private final Array array;
     private final Hash hash;
@@ -236,6 +242,19 @@ public class Value {
         return Arrays.copyOfRange(fields, 1, fields.length);
     }
 
+    private void transformFields(final String[] fields, final UnaryOperator<String> operator) {
+        switch (type) {
+            case Array:
+                asArray().transformFields(fields, operator);
+                break;
+            case Hash:
+                asHash().transformFields(fields, operator);
+                break;
+            default:
+                throw new IllegalStateException(UNEXPECTED + type);
+        }
+    }
+
     enum Type {
         Array,
         Hash,
@@ -396,6 +415,45 @@ public class Value {
             return result;
         }
 
+        private void transformFields(final String[] fields, final UnaryOperator<String> operator) {
+            final String field = fields[0];
+            final String[] remainingFields = tail(fields);
+            final int size = size();
+
+            if (fields.length == 0 || field.equals(ASTERISK)) {
+                for (int i = 0; i < size; ++i) {
+                    transformFields(i, remainingFields, operator);
+                }
+            }
+            else if (isNumber(field)) {
+                final int index = Integer.parseInt(field) - 1; // TODO: 0-based Catmandu vs. 1-based Metafacture
+                if (index >= 0 && index < size) {
+                    transformFields(index, remainingFields, operator);
+                }
+            }
+            // TODO: WDCD? copy_field('your.name','author[].name'), where name is an array
+            else {
+                for (int i = 0; i < size; ++i) {
+                    transformFields(i, fields, operator);
+                }
+            }
+
+            list.removeIf(v -> v == null);
+        }
+
+        private void transformFields(final int index, final String[] fields, final UnaryOperator<String> operator) {
+            final Value value = get(index);
+
+            if (value != null) {
+                if (value.isString()) {
+                    set(index, operator != null ? new Value(operator.apply(value.asString())) : null);
+                }
+                else {
+                    value.transformFields(fields, operator);
+                }
+            }
+        }
+
         private void insert(final InsertMode mode, final String[] fields, final String newValue) {
             switch (fields[0]) {
                 case ASTERISK:
@@ -448,8 +506,6 @@ public class Value {
 
         private static final String FIELD_PATH_SEPARATOR = "\\.";
 
-        private static final String UNEXPECTED = "expected array or hash, got ";
-
         private final Map<String, Value> map = new LinkedHashMap<>();
 
         /**
@@ -465,7 +521,7 @@ public class Value {
          * @return true if this hash contains the metadata field, false otherwise
          */
         public boolean containsField(final String field) {
-            return map.containsKey(field);
+            return map.keySet().stream().anyMatch(fieldMatcher(field));
         }
 
         /**
@@ -526,7 +582,9 @@ public class Value {
          * @return the metadata value
          */
         public Value get(final String field) {
-            return map.get(field);
+            // TODO: special treatment (only) for exact matches?
+            final List<Value> list = findFields(field).map(map::get).collect(Collectors.toList());
+            return list.isEmpty() ? null : list.size() == 1 ? list.get(0) : new Value(list);
         }
 
         public Value find(final String fieldPath) {
@@ -642,7 +700,7 @@ public class Value {
          * @param field the field name
          */
         public void remove(final String field) {
-            map.remove(field);
+            modifyFields(field, map::remove);
         }
 
         public void removeNested(final String fieldPath) {
@@ -706,14 +764,35 @@ public class Value {
         }
 
         public void transformFields(final List<String> params, final UnaryOperator<String> operator) {
-            final String field = params.get(0);
-            final Value value = find(field);
-            if (value != null) {
-                removeNested(field);
-                if (operator != null) {
-                    value.asList(a -> a.forEach(v -> append(field, operator.apply(v.toString()))));
-                }
+            transformFields(split(params.get(0)), operator);
+        }
+
+        private void transformFields(final String[] fields, final UnaryOperator<String> operator) {
+            final String field = fields[0];
+            final String[] remainingFields = tail(fields);
+
+            if (field.equals(ASTERISK)) {
+                // TODO: search in all elements of value.asHash()?
+                transformFields(remainingFields, operator);
+                return;
             }
+
+            modifyFields(field, f -> {
+                final Value value = map.get(f);
+
+                if (value != null) {
+                    if (remainingFields.length == 0) {
+                        map.remove(f);
+
+                        if (operator != null) {
+                            value.asList(a -> a.forEach(v -> append(f, operator.apply(v.toString()))));
+                        }
+                    }
+                    else {
+                        value.transformFields(remainingFields, operator);
+                    }
+                }
+            });
         }
 
         /**
@@ -722,7 +801,7 @@ public class Value {
          * @param fields the field names
          */
         public void retainFields(final Collection<String> fields) {
-            map.keySet().retainAll(fields);
+            map.keySet().retainAll(fields.stream().flatMap(this::findFields).collect(Collectors.toSet()));
         }
 
         /**
@@ -750,6 +829,21 @@ public class Value {
         @Override
         public String asString() {
             return map.toString();
+        }
+
+        private void modifyFields(final String pattern, final Consumer<String> consumer) {
+            findFields(pattern).collect(Collectors.toSet()).forEach(consumer);
+        }
+
+        private Stream<String> findFields(final String pattern) {
+            return map.keySet().stream().filter(fieldMatcher(pattern));
+        }
+
+        private Predicate<String> fieldMatcher(final String pattern) {
+            final SimpleRegexTrie<String> trie = new SimpleRegexTrie<>();
+            trie.put(pattern, pattern);
+
+            return field -> trie.get(field).contains(pattern);
         }
 
     }

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -522,7 +523,7 @@ public class Value {
          * @return true if this hash contains the metadata field, false otherwise
          */
         public boolean containsField(final String field) {
-            return map.keySet().stream().anyMatch(fieldMatcher(field));
+            return matchFields(field, Stream::anyMatch);
         }
 
         /**
@@ -837,12 +838,12 @@ public class Value {
         }
 
         private Stream<String> findFields(final String pattern) {
-            return map.keySet().stream().filter(fieldMatcher(pattern));
+            return matchFields(pattern, Stream::filter);
         }
 
-        private Predicate<String> fieldMatcher(final String pattern) {
+        private <T> T matchFields(final String pattern, final BiFunction<Stream<String>, Predicate<String>, T> function) {
             trie.put(pattern, pattern);
-            return field -> trie.get(field).contains(pattern);
+            return function.apply(map.keySet().stream(), f -> trie.get(f).contains(pattern));
         }
 
     }

--- a/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
@@ -25,6 +25,11 @@ public class HashValueTest {
 
     private static final String FIELD = "field";
     private static final String OTHER_FIELD = "other field";
+    private static final String ALTERNATE_FIELD = FIELD.replace("e", "i");
+
+    private static final String FIELD_CHARACTER_CLASS = FIELD.replace("e", "[aeiou]");
+    private static final String FIELD_ALTERNATION = FIELD + "|" + ALTERNATE_FIELD;
+    private static final String FIELD_WILDCARD = FIELD.replace("e", "?");
 
     private static final Value VALUE = new Value("value");
     private static final Value OTHER_VALUE = new Value("other value");
@@ -52,6 +57,30 @@ public class HashValueTest {
         hash.put(FIELD, null);
 
         Assertions.assertFalse(hash.containsField(FIELD));
+    }
+
+    @Test
+    public void shouldContainCharacterClassField() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+
+        Assertions.assertTrue(hash.containsField(FIELD_CHARACTER_CLASS));
+    }
+
+    @Test
+    public void shouldContainAlternationField() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+
+        Assertions.assertTrue(hash.containsField(FIELD_ALTERNATION));
+    }
+
+    @Test
+    public void shouldContainWildcardField() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+
+        Assertions.assertTrue(hash.containsField(FIELD_WILDCARD));
     }
 
     @Test
@@ -106,6 +135,57 @@ public class HashValueTest {
     }
 
     @Test
+    public void shouldGetSingleCharacterClassField() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+
+        Assertions.assertEquals(VALUE, hash.get(FIELD_CHARACTER_CLASS));
+    }
+
+    @Test
+    public void shouldGetSingleAlternationField() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+
+        Assertions.assertEquals(VALUE, hash.get(FIELD_ALTERNATION));
+    }
+
+    @Test
+    public void shouldGetSingleWildcardField() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+
+        Assertions.assertEquals(VALUE, hash.get(FIELD_WILDCARD));
+    }
+
+    @Test
+    public void shouldGetMultipleCharacterClassFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(ALTERNATE_FIELD, OTHER_VALUE);
+
+        assertArray(hash.get(FIELD_CHARACTER_CLASS));
+    }
+
+    @Test
+    public void shouldGetMultipleAlternationFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(ALTERNATE_FIELD, OTHER_VALUE);
+
+        assertArray(hash.get(FIELD_ALTERNATION));
+    }
+
+    @Test
+    public void shouldGetMultipleWildcardFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(ALTERNATE_FIELD, OTHER_VALUE);
+
+        assertArray(hash.get(FIELD_WILDCARD));
+    }
+
+    @Test
     public void shouldNotReplaceMissingField() {
         final Value.Hash hash = newHash();
         hash.replace(FIELD, VALUE);
@@ -152,6 +232,48 @@ public class HashValueTest {
     }
 
     @Test
+    public void shouldRemoveCharacterClassFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(ALTERNATE_FIELD, VALUE);
+        hash.remove(FIELD_CHARACTER_CLASS);
+
+        Assertions.assertTrue(hash.isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveAlternationFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(ALTERNATE_FIELD, VALUE);
+        hash.remove(FIELD_ALTERNATION);
+
+        Assertions.assertTrue(hash.isEmpty());
+    }
+
+    @Test
+    public void shouldRemoveWildcardFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(ALTERNATE_FIELD, VALUE);
+        hash.remove(FIELD_WILDCARD);
+
+        Assertions.assertTrue(hash.isEmpty());
+    }
+
+    @Test
+    public void shouldNotContainRemovedField() {
+        final Value.Hash hash = newHash();
+        Assertions.assertFalse(hash.containsField(FIELD));
+
+        hash.put(FIELD, VALUE);
+        Assertions.assertTrue(hash.containsField(FIELD));
+
+        hash.remove(FIELD);
+        Assertions.assertFalse(hash.containsField(FIELD));
+    }
+
+    @Test
     public void shouldRetainFields() {
         final Value.Hash hash = newHash();
         hash.put(FIELD, VALUE);
@@ -179,6 +301,42 @@ public class HashValueTest {
         hash.put(FIELD, VALUE);
 
         hash.retainFields(Arrays.asList(FIELD, OTHER_FIELD));
+
+        Assertions.assertTrue(hash.containsField(FIELD));
+        Assertions.assertFalse(hash.containsField(OTHER_FIELD));
+    }
+
+    @Test
+    public void shouldRetainCharacterClassFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(OTHER_FIELD, OTHER_VALUE);
+
+        hash.retainFields(Arrays.asList(FIELD_CHARACTER_CLASS));
+
+        Assertions.assertTrue(hash.containsField(FIELD));
+        Assertions.assertFalse(hash.containsField(OTHER_FIELD));
+    }
+
+    @Test
+    public void shouldRetainAlternationFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(OTHER_FIELD, OTHER_VALUE);
+
+        hash.retainFields(Arrays.asList(FIELD_ALTERNATION));
+
+        Assertions.assertTrue(hash.containsField(FIELD));
+        Assertions.assertFalse(hash.containsField(OTHER_FIELD));
+    }
+
+    @Test
+    public void shouldRetainWildcardFields() {
+        final Value.Hash hash = newHash();
+        hash.put(FIELD, VALUE);
+        hash.put(OTHER_FIELD, OTHER_VALUE);
+
+        hash.retainFields(Arrays.asList(FIELD_WILDCARD));
 
         Assertions.assertTrue(hash.containsField(FIELD));
         Assertions.assertFalse(hash.containsField(OTHER_FIELD));
@@ -215,6 +373,15 @@ public class HashValueTest {
 
     private Value.Hash newHash() {
         return Value.newHash().asHash();
+    }
+
+    private void assertArray(final Value result) {
+        Assertions.assertTrue(result.isArray());
+
+        final Value.Array array = result.asArray();
+        Assertions.assertEquals(2, array.size());
+        Assertions.assertEquals(VALUE, array.get(0));
+        Assertions.assertEquals(OTHER_VALUE, array.get(1));
     }
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -21,7 +21,6 @@ import org.metafacture.framework.StreamReceiver;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -393,7 +392,6 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("Use SimpleRegexTrie/WildcardTrie")
     public void alternation() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "trim('title-1|title-2')"),
@@ -413,8 +411,8 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().literal("title-2", "marc");
-                o.get().literal("title-1", "json");
+                o.get().literal("title-1", "marc");
+                o.get().literal("title-2", "json");
                 o.get().endRecord();
 
                 o.get().startRecord("3");
@@ -423,7 +421,6 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("Use SimpleRegexTrie/WildcardTrie")
     public void wildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "trim('title-?')"),
@@ -443,8 +440,8 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().literal("title-2", "marc");
-                o.get().literal("title-1", "json");
+                o.get().literal("title-1", "marc");
+                o.get().literal("title-2", "json");
                 o.get().endRecord();
 
                 o.get().startRecord("3");
@@ -453,7 +450,6 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("Use SimpleRegexTrie")
     public void characterClass() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "trim('title-[12]')"),
@@ -473,8 +469,8 @@ public class MetafixMethodTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().literal("title-2", "marc");
-                o.get().literal("title-1", "json");
+                o.get().literal("title-1", "marc");
+                o.get().literal("title-2", "json");
                 o.get().endRecord();
 
                 o.get().startRecord("3");

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -479,6 +479,198 @@ public class MetafixRecordTest {
     }
 
     @Test
+    public void appendWithWildcard() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "copy_field('?nimal', 'stringimals[].$append')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animal", "dog");
+                i.literal("bnimal", "cat");
+                i.literal("cnimal", "zebra");
+                i.literal("dnimol", "bunny");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("animal", "dog");
+                o.get().literal("bnimal", "cat");
+                o.get().literal("cnimal", "zebra");
+                o.get().literal("dnimol", "bunny");
+                o.get().startEntity("stringimals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    // See https://github.com/metafacture/metafacture-fix/issues/99
+    public void simpleCopyWithWildcard() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "copy_field('?nimal', 'animal')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animal", "dog");
+                i.endRecord();
+                i.startRecord("2");
+                i.literal("bnimal", "cat");
+                i.endRecord();
+                i.startRecord("3");
+                i.literal("cnimal", "zebra");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animal");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "dog");
+                o.get().endEntity();
+                o.get().endRecord();
+                o.get().startRecord("2");
+                o.get().literal("bnimal", "cat");
+                o.get().literal("animal", "cat");
+                o.get().endRecord();
+                o.get().startRecord("3");
+                o.get().literal("cnimal", "zebra");
+                o.get().literal("animal", "zebra");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void appendWithMultipleWildcards() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "copy_field('?ni??l', 'stringimals[].$append')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animal", "dog");
+                i.literal("bnimal", "cat");
+                i.literal("cnimal", "zebra");
+                i.literal("dnimol", "bunny");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("animal", "dog");
+                o.get().literal("bnimal", "cat");
+                o.get().literal("cnimal", "zebra");
+                o.get().literal("dnimol", "bunny");
+                o.get().startEntity("stringimals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().literal("4", "bunny");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void appendWithAsteriksWildcard() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "copy_field('*al', 'stringimals[].$append')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animal", "dog");
+                i.literal("bnimal", "cat");
+                i.literal("cnimal", "zebra");
+                i.literal("dnimol", "bunny");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("animal", "dog");
+                o.get().literal("bnimal", "cat");
+                o.get().literal("cnimal", "zebra");
+                o.get().literal("dnimol", "bunny");
+                o.get().startEntity("stringimals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void appendWithBracketWildcard() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "copy_field('[ac]nimal', 'stringimals[].$append')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animal", "dog");
+                i.literal("bnimal", "cat");
+                i.literal("cnimal", "zebra");
+                i.literal("dnimol", "bunny");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("animal", "dog");
+                o.get().literal("bnimal", "cat");
+                o.get().literal("cnimal", "zebra");
+                o.get().literal("dnimol", "bunny");
+                o.get().startEntity("stringimals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "zebra");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    // See https://github.com/metafacture/metafacture-fix/issues/89
+    public void appendWithAsteriksWildcardAtTheEnd() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "copy_field('ani*', 'stringimals[].$append')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animals", "dog");
+                i.literal("animals", "cat");
+                i.literal("animals", "zebra");
+                i.literal("animal", "bunny");
+                i.startEntity("animols");
+                i.literal("name", "bird");
+                i.literal("type", "TEST");
+                i.endEntity();
+                i.literal("ANIMALS", "dragon and unicorn");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().endEntity();
+                o.get().literal("animal", "bunny");
+                o.get().startEntity("animols");
+                o.get().literal("name", "bird");
+                o.get().literal("type", "TEST");
+                o.get().endEntity();
+                o.get().literal("ANIMALS", "dragon and unicorn");
+                o.get().startEntity("stringimals[]");
+                o.get().literal("1", "bunny");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void move() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(// TODO: dot noation in move_field
                 "move_field('my.name','your.name')",

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1174,7 +1174,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("TODO: WDCD? explicit * for array fields?")
+    // TODO: WDCD? explicit * for array fields?
     public void accessArrayByWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "upcase('name.*')"),
@@ -1246,7 +1246,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("TODO: implement implicit iteration?")
+    // TODO: implement implicit iteration?
     public void accessArrayOfObjectsByWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "upcase('author.*.name')",


### PR DESCRIPTION
Delegates `Value.Hash` retrieval to `SimpleRegexTrie` for pattern matching.

All operations involving field patterns must be translated to concrete field names.

NOTE: Requires (a lot) more tests. But existing tests, including previously disabled ones, are already providing some coverage - with _trivial_ (?) modifications to make them pass (not sure why they were testing the wrong order).

Resolves #89.