### PR TITLE
Reduce test output.

### DIFF
--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-  id 'com.adarshr.test-logger' version '1.7.0'
   id 'maven-publish'
 }
 
@@ -44,8 +43,10 @@ dependencies {
 test {
   useJUnitPlatform()
 
-  testlogger {
-    showFullStackTraces true
+  testLogging {
+    showStandardStreams = true
+    exceptionFormat = 'full'
+    events 'SKIPPED'
   }
 }
 

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -48,6 +48,8 @@ test {
     exceptionFormat = 'full'
     events 'SKIPPED'
   }
+
+  maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 task install(dependsOn: publishToMavenLocal,

--- a/metafix/src/main/java/org/metafacture/metafix/interpreter/FixInterpreter.java
+++ b/metafix/src/main/java/org/metafacture/metafix/interpreter/FixInterpreter.java
@@ -11,9 +11,12 @@ import org.metafacture.metafix.fix.MethodCall;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter;
-import org.eclipse.xtext.xbase.lib.InputOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FixInterpreter extends XbaseInterpreter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FixInterpreter.class);
 
     private Metafix metafix;
 
@@ -41,7 +44,7 @@ public class FixInterpreter extends XbaseInterpreter {
             matched = true;
 
             final If ifExpression = (If) expression;
-            InputOutput.println("if: " + ifExpression);
+            LOG.debug("if: " + ifExpression);
 
             for (final Expression element : ifExpression.getElements()) {
                 process(element);
@@ -49,7 +52,7 @@ public class FixInterpreter extends XbaseInterpreter {
 
             final ElsIf elseIfExpression = ifExpression.getElseIf();
             if (elseIfExpression != null) {
-                InputOutput.println("else if: " + elseIfExpression);
+                LOG.debug("else if: " + elseIfExpression);
 
                 for (final Expression element : elseIfExpression.getElements()) {
                     process(element);
@@ -58,7 +61,7 @@ public class FixInterpreter extends XbaseInterpreter {
 
             final Else elseExpression = ifExpression.getElse();
             if (elseExpression != null) {
-                InputOutput.println("else: " + elseExpression);
+                LOG.debug("else: " + elseExpression);
 
                 for (final Expression element : elseExpression.getElements()) {
                     process(element);
@@ -71,7 +74,7 @@ public class FixInterpreter extends XbaseInterpreter {
                 matched = true;
 
                 final Do doExpression = (Do) expression;
-                InputOutput.println("do: " + doExpression);
+                LOG.debug("do: " + doExpression);
 
                 for (final Expression element : doExpression.getElements()) {
                     process(element);
@@ -82,7 +85,7 @@ public class FixInterpreter extends XbaseInterpreter {
         if (!matched) {
             if (expression instanceof MethodCall) {
                 matched = true;
-                InputOutput.println("method call: " + expression);
+                LOG.debug("method call: " + expression);
                 // TODO
             }
         }

--- a/metafix/src/test/java/org/metafacture/metafix/FixParsingTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/FixParsingTest.java
@@ -9,7 +9,6 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.eclipse.xtext.testing.util.ParseHelper;
-import org.eclipse.xtext.xbase.lib.InputOutput;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -108,7 +107,6 @@ public class FixParsingTest {
 
     private void parse(final String... fix) throws Exception {
         final Fix result = parseHelper.parse(String.join("\n", fix));
-        InputOutput.println("Result: " + result);
         Assertions.assertNotNull(result);
 
         final EList<Resource.Diagnostic> errors = result.eResource().getErrors();

--- a/metafix/src/test/java/org/metafacture/metafix/InterpreterTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/InterpreterTest.java
@@ -9,7 +9,6 @@ import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.eclipse.xtext.testing.util.ParseHelper;
 import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.InputOutput;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,8 +52,7 @@ public class InterpreterTest {
         Assert.assertTrue(metafix.getExpressions().isEmpty());
 
         fixInterpreter.run(metafix, parseHelper.parse(String.join("\n", fix)));
-        InputOutput.println("metafix expressions: " + metafix.getExpressions());
-        Assert.assertEquals(expressions, metafix.getExpressions().size());
+        Assert.assertEquals("metafix expressions: " + metafix.getExpressions(), expressions, metafix.getExpressions().size());
     }
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
@@ -75,13 +75,13 @@ public final class MetafixTestHelpers {
             Mockito.verifyNoMoreInteractions(receiver);
         }
         catch (final MockitoAssertionError e) {
+            System.out.println("\nFix string: " + fixString);
             System.out.println(Mockito.mockingDetails(receiver).printInvocations());
             throw e;
         }
     }
 
     private static Metafix fix(final StreamReceiver receiver, final String fix, final Map<String, String> vars) {
-        System.out.println("\nFix string: " + fix);
         Metafix metafix = null;
         try {
             metafix = new Metafix(fix, vars);


### PR DESCRIPTION
How invested are you in the current test output? I feel, as our test suite grows, it's becoming a little unwieldy. So I'd like to propose a more compact version.

Passing:

- Before (cropped): ![passing-before](https://user-images.githubusercontent.com/20381/147222392-5469bee6-377a-446f-9ce0-73dfc57327b6.png)
- After: ![passing-after](https://user-images.githubusercontent.com/20381/147222444-4ec7b4b6-45af-42cc-990b-38dccf808d55.png)

Failing:

- Before (cropped): ![failing-before](https://user-images.githubusercontent.com/20381/147222469-74704eab-e691-4c74-b90f-a4e052284c5c.png)
- After: ![failing-after](https://user-images.githubusercontent.com/20381/147222487-f65d8d8f-3a38-4acd-b4e3-35f32b25a945.png)