### PR TITLE
Add Fix functions from Catmandu Cheat Sheet.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ subprojects {
   ext {
     versions = [
       'ace':            '1.3.3',
+      'equalsverifier': '3.8.2',
       'jetty':          '9.4.14.v20181114',
       'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.4.2',

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation "org.metafacture:metafacture-flowcontrol:${versions.metafacture}"
   implementation "org.metafacture:metamorph:${versions.metafacture}"
 
+  testImplementation "nl.jqno.equalsverifier:equalsverifier:${versions.equalsverifier}"
   testImplementation "org.mockito:mockito-core:${versions.mockito}"
   testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"
 }

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -397,6 +397,11 @@ enum FixMethod {
             record.transformFields(params, String::trim);
         }
     },
+    uniq {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            record.transformField(params.get(0), v -> v.isArray() ? newArray(unique(v.asArray().stream())) : null);
+        }
+    },
     upcase {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.transformFields(params, String::toUpperCase);

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -30,6 +30,11 @@ enum FixMethod {
 
     // SCRIPT-LEVEL METHODS:
 
+    nothing {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            // do nothing
+        }
+    },
     put_filemap {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final String fileName = params.get(0);

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -386,6 +386,12 @@ enum FixMethod {
             record.transformFields(params, s -> s.substring(getInteger(params, 1), getInteger(params, 2) - 1));
         }
     },
+    sum {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            record.transformField(params.get(0), v ->
+                    v.isArray() ? new Value(v.asArray().stream().map(Value::asString).mapToInt(Integer::parseInt).sum()) : null);
+        }
+    },
     trim {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.transformFields(params, String::trim);

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -22,6 +22,7 @@ import org.metafacture.metamorph.maps.FileMap;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -165,6 +166,14 @@ enum FixMethod {
             return s.startsWith("~");
         }
     },
+    random {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final String field = params.get(0);
+            final int max = getInteger(params, 1);
+
+            record.append(field, String.valueOf(RANDOM.nextInt(max)));
+        }
+    },
     reject {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.setReject(true);
@@ -258,7 +267,7 @@ enum FixMethod {
     },
     substring {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-            record.transformFields(params, s -> s.substring(Integer.parseInt(params.get(1)), Integer.parseInt(params.get(2)) - 1));
+            record.transformFields(params, s -> s.substring(getInteger(params, 1), getInteger(params, 2) - 1));
         }
     },
     trim {
@@ -279,6 +288,12 @@ enum FixMethod {
 
     private static final String FILEMAP_SEPARATOR_OPTION = "sep_char";
     private static final String FILEMAP_DEFAULT_SEPARATOR = ",";
+
+    private static final Random RANDOM = new Random();
+
+    private static int getInteger(final List<String> params, final int index) {
+        return Integer.parseInt(params.get(index));
+    }
 
     abstract void apply(Metafix metafix, Record record, List<String> params, Map<String, String> options);
 

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -20,6 +20,7 @@ import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.maps.FileMap;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -320,6 +321,27 @@ enum FixMethod {
             final String replace = params.get(2);
 
             record.transformFields(params, s -> s.replaceAll(search, replace));
+        }
+    },
+    reverse {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            record.transformField(params.get(0), v -> {
+                final Value result;
+
+                if (v.isString()) {
+                    result = new Value(new StringBuilder(v.asString()).reverse().toString());
+                }
+                else if (v.isArray()) {
+                    final List<Value> list = v.asArray().stream().collect(Collectors.toList());
+                    Collections.reverse(list);
+                    result = new Value(list);
+                }
+                else {
+                    result = null;
+                }
+
+                return result;
+            });
         }
     },
     substring {

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -293,6 +293,14 @@ enum FixMethod {
             record.transformFields(params, s -> String.valueOf(s.indexOf(search))); // TODO: multiple
         }
     },
+    join_field {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            record.transformField(params.get(0), v -> {
+                final String joinChar = params.size() > 1 ? params.get(1) : "";
+                return v.isArray() ? new Value(v.asArray().stream().map(Value::toString).collect(Collectors.joining(joinChar))) : null;
+            });
+        }
+    },
     lookup {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final Map<String, String> map;

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -308,6 +308,12 @@ enum FixMethod {
             record.transformFields(params, k -> map.getOrDefault(k, defaultValue));
         }
     },
+    prepend {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final String value = params.get(1);
+            record.transformFields(params, s -> value + s);
+        }
+    },
     substring {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.transformFields(params, s -> s.substring(getInteger(params, 1), getInteger(params, 2) - 1));

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -257,6 +257,12 @@ enum FixMethod {
             record.transformFields(params, s -> s.substring(0, 1).toUpperCase() + s.substring(1));
         }
     },
+    count {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            record.transformField(params.get(0), v ->
+                    v.isArray() ? new Value(v.asArray().size()) : v.isHash() ? new Value(v.asHash().size()) : null);
+        }
+    },
     downcase {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.transformFields(params, String::toLowerCase);

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -246,6 +246,12 @@ enum FixMethod {
 
     // TODO SPEC: switch to morph-style named params in general?
 
+    append {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final String value = params.get(1);
+            record.transformFields(params, s -> s + value);
+        }
+    },
     capitalize {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.transformFields(params, s -> s.substring(0, 1).toUpperCase() + s.substring(1));

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -281,6 +281,12 @@ enum FixMethod {
             });
         }
     },
+    index {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final String search = params.get(1);
+            record.transformFields(params, s -> String.valueOf(s.indexOf(search))); // TODO: multiple
+        }
+    },
     lookup {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final Map<String, String> map;

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -112,7 +112,7 @@ enum FixMethod {
 
             record.getList(field, a -> record.put(field, Value.newHash(h -> {
                 for (int i = 1; i < a.size(); i = i + 2) {
-                    h.put(a.get(i - 1).toString(), a.get(i));
+                    h.put(a.get(i - 1).asString(), a.get(i));
                 }
             })));
         }
@@ -129,7 +129,7 @@ enum FixMethod {
 
             record.getList(field, a -> a.forEach(v -> {
                 final Pattern p = Pattern.compile(params.get(1));
-                final Matcher m = p.matcher(v.toString());
+                final Matcher m = p.matcher(v.asString());
                 if (m.matches()) {
                     record.remove(field);
 
@@ -166,7 +166,7 @@ enum FixMethod {
             record.replace(params.get(0), params.subList(1, params.size()).stream()
                     .filter(f -> literalString(f) || record.find(f) != null)
                     .map(f -> literalString(f) ? new Value(f.substring(1)) : record.findList(f, null).asArray().get(0))
-                    .map(Value::toString).collect(Collectors.joining(joinChar != null ? joinChar : " ")));
+                    .map(Value::asString).collect(Collectors.joining(joinChar != null ? joinChar : " ")));
         }
 
         private boolean literalString(final String s) {
@@ -295,7 +295,7 @@ enum FixMethod {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final String joinChar = params.size() > 1 ? params.get(1) : "";
             record.transformField(params.get(0), (m, c) -> m
-                    .ifArray(a -> c.accept(new Value(a.stream().map(Value::toString).collect(Collectors.joining(joinChar)))))
+                    .ifArray(a -> c.accept(new Value(a.stream().map(Value::asString).collect(Collectors.joining(joinChar)))))
             );
         }
     },

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -178,7 +178,7 @@ enum FixMethod {
             final String field = params.get(0);
             final int max = getInteger(params, 1);
 
-            record.append(field, String.valueOf(RANDOM.nextInt(max)));
+            record.replace(field, String.valueOf(RANDOM.nextInt(max)));
         }
     },
     reject {
@@ -221,10 +221,7 @@ enum FixMethod {
     },
     set_field {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-            final String field = params.get(0);
-
-            record.remove(field);
-            record.replace(field, params.get(1));
+            record.replace(params.get(0), params.get(1));
         }
     },
     set_hash {

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -314,6 +314,14 @@ enum FixMethod {
             record.transformFields(params, s -> value + s);
         }
     },
+    replace_all {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final String search = params.get(1);
+            final String replace = params.get(2);
+
+            record.transformFields(params, s -> s.replaceAll(search, replace));
+        }
+    },
     substring {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.transformFields(params, s -> s.substring(getInteger(params, 1), getInteger(params, 2) - 1));

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -184,6 +184,18 @@ enum FixMethod {
             params.forEach(record::removeNested);
         }
     },
+    rename {
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            record.transformField(params.get(0), v -> {
+                final String search = params.get(1);
+                final String replace = params.get(2);
+
+                // TODO: recurse into arrays/values
+                return v.isHash() ? Value.newHash(h ->
+                        v.asHash().forEach((f, w) -> h.put(f.replaceAll(search, replace), w))) : null;
+            });
+        }
+    },
     retain {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             record.retainFields(params);

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -153,9 +153,11 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
             }
 
             for (int i = 0; i < array.size(); ++i) {
+                final Value currentValue = array.get(i);
                 final String fieldName = isMulti ? String.valueOf(i + 1) : field;
 
-                array.get(i).matchType()
+                currentValue.matchType()
+                    .ifArray(a -> emit(fieldName, currentValue))
                     .ifHash(h -> {
                         outputStreamReceiver.startEntity(fieldName);
                         h.forEach(this::emit);

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -132,7 +132,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     public void endRecord() {
         entityCountStack.removeLast();
         if (!entityCountStack.isEmpty()) {
-            throw new IllegalStateException(ENTITIES_NOT_BALANCED);
+            throw new MetafactureException(new IllegalStateException(ENTITIES_NOT_BALANCED));
         }
         flattener.endRecord();
         LOG.debug("End record, walking fix: {}", currentRecord);

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -209,6 +210,31 @@ public class Value {
         final AtomicReference<T> result = new AtomicReference<>();
         consumer.accept(matchType(), result::set);
         return result.get();
+    }
+
+    @Override
+    public final boolean equals(final Object object) {
+        if (object == this) {
+            return true;
+        }
+
+        if (!(object instanceof Value)) {
+            return false;
+        }
+
+        final Value other = (Value) object;
+        return Objects.equals(type, other.type) &&
+            Objects.equals(array, other.array) &&
+            Objects.equals(hash, other.hash) &&
+            Objects.equals(string, other.string);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(type) +
+            Objects.hashCode(array) +
+            Objects.hashCode(hash) +
+            Objects.hashCode(string);
     }
 
     @Override

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -211,7 +211,7 @@ public class Value {
         return new TypeMatcher(this);
     }
 
-    private <T> T extractType(final BiConsumer<TypeMatcher, Consumer<T>> consumer) {
+    public <T> T extractType(final BiConsumer<TypeMatcher, Consumer<T>> consumer) {
         final AtomicReference<T> result = new AtomicReference<>();
         consumer.accept(matchType(), result::set);
         return result.get();

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -210,7 +210,7 @@ public class Value {
         return new TypeMatcher(this);
     }
 
-    public <T> T extractType(final BiConsumer<TypeMatcher, Consumer<T>> consumer) {
+    private <T> T extractType(final BiConsumer<TypeMatcher, Consumer<T>> consumer) {
         final AtomicReference<T> result = new AtomicReference<>();
         consumer.accept(matchType(), result::set);
         return result.get();
@@ -839,11 +839,11 @@ public class Value {
             }
         }
 
-        public void transformField(final String field, final UnaryOperator<Value> operator) {
+        public void transformField(final String field, final BiConsumer<TypeMatcher, Consumer<Value>> consumer) {
             final Value oldValue = find(field);
 
             if (oldValue != null) {
-                final Value newValue = operator.apply(oldValue);
+                final Value newValue = oldValue.extractType(consumer);
 
                 if (newValue != null) {
                     insert(InsertMode.REPLACE, split(field), newValue);

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -210,7 +210,7 @@ public class Value {
         return new TypeMatcher(this);
     }
 
-    private <T> T extractType(final BiConsumer<TypeMatcher, Consumer<T>> consumer) {
+    public <T> T extractType(final BiConsumer<TypeMatcher, Consumer<T>> consumer) {
         final AtomicReference<T> result = new AtomicReference<>();
         consumer.accept(matchType(), result::set);
         return result.get();

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -458,7 +458,7 @@ public class Value {
                 }
             }
 
-            list.removeIf(v -> v == null);
+            list.removeIf(v -> Value.isNull(v));
         }
 
         private void transformFields(final int index, final String[] fields, final UnaryOperator<String> operator) {
@@ -849,7 +849,9 @@ public class Value {
                         map.remove(f);
 
                         if (operator != null) {
-                            value.asList(a -> a.forEach(v -> append(f, operator.apply(v.asString()))));
+                            value.matchType()
+                                .ifString(s -> append(f, operator.apply(s)))
+                                .orElseThrow();
                         }
                     }
                     else {

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -835,6 +835,18 @@ public class Value {
             }
         }
 
+        public void transformField(final String field, final UnaryOperator<Value> operator) {
+            final Value oldValue = find(field);
+
+            if (oldValue != null) {
+                final Value newValue = operator.apply(oldValue);
+
+                if (newValue != null) {
+                    insert(InsertMode.REPLACE, split(field), newValue);
+                }
+            }
+        }
+
         public void transformFields(final List<String> params, final UnaryOperator<String> operator) {
             transformFields(split(params.get(0)), operator);
         }

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -17,6 +17,7 @@
 package org.metafacture.metafix;
 
 import org.metafacture.commons.tries.SimpleRegexTrie;
+import org.metafacture.framework.MetafactureException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -298,7 +299,7 @@ public class Value {
         public void orElseThrow() {
             orElse(v -> {
                 final String types = expected.stream().map(Type::name).collect(Collectors.joining(" or "));
-                throw new IllegalStateException("expected " + types + ", got " + value.type);
+                throw new MetafactureException(new IllegalStateException("expected " + types + ", got " + value.type));
             });
         }
 
@@ -311,7 +312,7 @@ public class Value {
                 return this;
             }
             else {
-                throw new IllegalStateException("already expecting " + type);
+                throw new MetafactureException(new IllegalStateException("already expecting " + type));
             }
         }
 
@@ -848,7 +849,7 @@ public class Value {
                         map.remove(f);
 
                         if (operator != null) {
-                            value.asList(a -> a.forEach(v -> append(f, operator.apply(v.toString()))));
+                            value.asList(a -> a.forEach(v -> append(f, operator.apply(v.asString()))));
                         }
                     }
                     else {

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -106,6 +106,10 @@ public class Value {
         this.string = string;
     }
 
+    public Value(final int integer) {
+        this(String.valueOf(integer));
+    }
+
     public static Value newArray() {
         return newArray(null);
     }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -39,6 +39,8 @@ public class MetafixLookupTest {
     private static final String CSV_MAP = "src/test/resources/org/metafacture/metafix/maps/test.csv";
     private static final String TSV_MAP = "src/test/resources/org/metafacture/metafix/maps/test.tsv";
 
+    private static final String LOOKUP = "lookup('title.*',";
+
     @Mock
     private StreamReceiver streamReceiver;
 
@@ -48,14 +50,14 @@ public class MetafixLookupTest {
     @Test
     public void inline() {
         assertMap(
-                "lookup('title', Aloha: Alohaeha, 'Moin': 'Moin zäme', __default: Tach)"
+                LOOKUP + " Aloha: Alohaeha, 'Moin': 'Moin zäme', __default: Tach)"
         );
     }
 
     @Test
     public void inlineMultilineIndent() {
         assertMap(
-                "lookup('title',",
+                LOOKUP,
                 "  Aloha: Alohaeha,",
                 "  Moin: 'Moin zäme',",
                 "  __default: Tach)"
@@ -65,7 +67,7 @@ public class MetafixLookupTest {
     @Test
     public void inlineDotNotationNested() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "lookup('data.title', Aloha: Alohaeha, 'Moin': 'Moin zäme', __default: Tach)"
+                "lookup('data.title.*', Aloha: Alohaeha, 'Moin': 'Moin zäme', __default: Tach)"
             ),
             i -> {
                 i.startRecord("1");
@@ -92,14 +94,14 @@ public class MetafixLookupTest {
     @Test
     public void csv() {
         assertMap(
-                "lookup('title', '" + CSV_MAP + "')"
+                LOOKUP + " '" + CSV_MAP + "')"
         );
     }
 
     @Test
     public void tsv() {
         assertMap(
-                "lookup('title', '" + TSV_MAP + "', sep_char:'\t')"
+                LOOKUP + " '" + TSV_MAP + "', sep_char:'\t')"
         );
     }
 
@@ -107,7 +109,7 @@ public class MetafixLookupTest {
     public void shouldLookupInSeparateInternalMap() {
         assertMap(
                 "put_map('testMap', Aloha: Alohaeha, 'Moin': 'Moin zäme', __default: Tach)",
-                "lookup('title', 'testMap')"
+                LOOKUP + " 'testMap')"
         );
     }
 
@@ -115,7 +117,7 @@ public class MetafixLookupTest {
     public void shouldLookupInSeparateExternalFileMap() {
         assertMap(
                 "put_filemap('" + CSV_MAP + "')",
-                "lookup('title', '" + CSV_MAP + "')"
+                LOOKUP + " '" + CSV_MAP + "')"
         );
     }
 
@@ -123,7 +125,7 @@ public class MetafixLookupTest {
     public void shouldLookupInSeparateExternalFileMapWithName() {
         assertMap(
                 "put_filemap('" + CSV_MAP + "', 'testMap')",
-                "lookup('title', 'testMap')"
+                LOOKUP + " 'testMap')"
         );
     }
 
@@ -131,7 +133,7 @@ public class MetafixLookupTest {
     public void shouldLookupInSeparateExternalFileMapWithOptions() {
         assertMap(
                 "put_filemap('" + TSV_MAP + "', sep_char: '\t')",
-                "lookup('title', '" + TSV_MAP + "')"
+                LOOKUP + " '" + TSV_MAP + "')"
         );
     }
 
@@ -139,7 +141,7 @@ public class MetafixLookupTest {
     public void shouldLookupInSeparateExternalFileMapWithNameAndOptions() {
         assertMap(
                 "put_filemap('" + TSV_MAP + "', 'testMap', sep_char: '\t')",
-                "lookup('title', 'testMap')"
+                LOOKUP + " 'testMap')"
         );
     }
 
@@ -148,7 +150,7 @@ public class MetafixLookupTest {
         assertMap(
                 "put_map('testMap', Aloha: Alohaeha, 'Moin': 'Moin zäme', __default: Tach)",
                 "put_map('testMap2', __default: Hi)",
-                "lookup('title', 'testMap')"
+                LOOKUP + " 'testMap')"
         );
     }
 
@@ -157,7 +159,7 @@ public class MetafixLookupTest {
         assertMap(
                 "put_map('testMap', __default: Hi)",
                 "put_filemap('" + CSV_MAP + "', 'testMap')",
-                "lookup('title', 'testMap')"
+                LOOKUP + " 'testMap')"
         );
     }
 
@@ -165,7 +167,7 @@ public class MetafixLookupTest {
     public void shouldIgnoreOptionsOnLookupInSeparateInternalMap() {
         assertMap(
                 "put_map('testMap', Aloha: Alohaeha, 'Moin': 'Moin zäme', __default: Tach)",
-                "lookup('title', 'testMap', __default: Hi)"
+                LOOKUP + " 'testMap', __default: Hi)"
         );
     }
 
@@ -173,14 +175,14 @@ public class MetafixLookupTest {
     public void shouldIgnoreOptionsOnLookupInSeparateExternalFileMap() {
         assertMap(
                 "put_filemap('" + CSV_MAP + "')",
-                "lookup('title', '" + CSV_MAP + "', sep_char: '\t')"
+                LOOKUP + " '" + CSV_MAP + "', sep_char: '\t')"
         );
     }
 
     @Test
     public void shouldNotLookupInExternalFileMapWithWrongOptions() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "lookup('title', '" + CSV_MAP + "', sep_char: '\t')"
+                LOOKUP + " '" + CSV_MAP + "', sep_char: '\t')"
             ),
             i -> {
                 i.startRecord("1");
@@ -191,6 +193,8 @@ public class MetafixLookupTest {
             },
             o -> {
                 o.get().startRecord("1");
+                o.get().startEntity("title");
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -199,8 +203,8 @@ public class MetafixLookupTest {
     @Test
     public void shouldIgnoreOptionsOnSubsequentLookupInExternalFileMap() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "lookup('title', '" + CSV_MAP + "')",
-                "lookup('title', '" + CSV_MAP + "', sep_char: '\t')"
+                LOOKUP + " '" + CSV_MAP + "')",
+                LOOKUP + " '" + CSV_MAP + "', sep_char: '\t')"
             ),
             i -> {
                 i.startRecord("1");
@@ -225,7 +229,7 @@ public class MetafixLookupTest {
     public void shouldFailLookupInUnknownNamedMap() {
         final Throwable exception = Assertions.assertThrows(MorphExecutionException.class, () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                    "lookup('title', 'testMap')"
+                    LOOKUP + " 'testMap')"
                 ),
                 i -> {
                     i.startRecord("1");

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -229,7 +229,7 @@ public class MetafixLookupTest {
 
     @Test
     public void shouldFailLookupInUnknownNamedMap() {
-        Assertions.assertThrows(MorphExecutionException.class, () ->
+        final Throwable exception = Assertions.assertThrows(MorphExecutionException.class, () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "lookup('title', 'testMap')"
                 ),
@@ -242,9 +242,10 @@ public class MetafixLookupTest {
                 },
                 o -> {
                 }
-            ),
-            "File not found: testMap"
+            )
         );
+
+        Assertions.assertEquals("File not found: testMap", exception.getMessage());
     }
 
     private void assertMap(final String... fixDef) {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -1262,6 +1262,35 @@ public class MetafixMethodTest {
     }
 
     @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldSplitNestedField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "split_field('others[].*.tools', '--')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("others[]");
+                i.startEntity("1");
+                i.literal("tools", "hammer--saw--bow");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("others[]");
+                o.get().startEntity("1");
+                o.get().startEntity("tools");
+                o.get().literal("1", "hammer");
+                o.get().literal("2", "saw");
+                o.get().literal("3", "bow");
+                f.apply(3).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldSumNumbers() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "sum(numbers)"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -626,6 +626,27 @@ public class MetafixMethodTest {
     }
 
     @Test
+    public void shouldJoinArrayField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "join_field(numbers, '/')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "6");
+                i.literal("numbers", "42");
+                i.literal("numbers", "41");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("numbers", "6/42/41/6");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldPrependValue() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "prepend(title, 'I love ')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -21,6 +21,7 @@ import org.metafacture.framework.StreamReceiver;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -512,6 +513,112 @@ public class MetafixMethodTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().literal("title", "metafix ?!");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    // TODO: Fix order (`animols.name` should stay before `animols.type`)
+    public void shouldAppendValueInHash() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "append(animols.name, ' boss')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animols");
+                i.literal("name", "bird");
+                i.literal("type", "TEST");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animols");
+                o.get().literal("type", "TEST");
+                o.get().literal("name", "bird boss");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    // TODO: Fix order (`animals[].1` should stay before `animals[].2`)
+    public void shouldAppendValueInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "append('animals[].1', ' is cool')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().literal("1", "dog is cool");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldAppendValueInEntireArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "append('animals[].*', ' is cool')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "dog is cool");
+                o.get().literal("2", "cat is cool");
+                o.get().literal("3", "zebra is cool");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldNotAppendValueToArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "append('animals[]', ' is cool')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -701,6 +701,155 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldSortField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "sort_field(numbers)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "6");
+                i.literal("numbers", "42");
+                i.literal("numbers", "41");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("numbers");
+                o.get().literal("1", "41");
+                o.get().literal("2", "42");
+                o.get().literal("3", "6");
+                o.get().literal("4", "6");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldSortFieldNumerically() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "sort_field(numbers, numeric: 'true')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "6");
+                i.literal("numbers", "42");
+                i.literal("numbers", "41");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("numbers");
+                o.get().literal("1", "6");
+                o.get().literal("2", "6");
+                o.get().literal("3", "41");
+                o.get().literal("4", "42");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldFailToSortNumericallyWithInvalidNumber() {
+        assertThrows(NumberFormatException.class, "For input string: \"x\"", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "sort_field(numbers, numeric: 'true')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("numbers", "6");
+                    i.literal("numbers", "42");
+                    i.literal("numbers", "x");
+                    i.literal("numbers", "6");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldSortFieldInReverse() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "sort_field(numbers, reverse: 'true')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "6");
+                i.literal("numbers", "42");
+                i.literal("numbers", "41");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("numbers");
+                o.get().literal("1", "6");
+                o.get().literal("2", "6");
+                o.get().literal("3", "42");
+                o.get().literal("4", "41");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldSortFieldNumericallyInReverse() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "sort_field(numbers, numeric: 'true', reverse: 'true')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "6");
+                i.literal("numbers", "42");
+                i.literal("numbers", "41");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("numbers");
+                o.get().literal("1", "42");
+                o.get().literal("2", "41");
+                o.get().literal("3", "6");
+                o.get().literal("4", "6");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldSortFieldAndRemoveDuplicates() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "sort_field(numbers, uniq: 'true')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "6");
+                i.literal("numbers", "42");
+                i.literal("numbers", "41");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("numbers");
+                o.get().literal("1", "41");
+                o.get().literal("2", "42");
+                o.get().literal("3", "6");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -607,6 +607,24 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldGetIndexOfSubstring() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "index(title, 't')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "metafix");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "2");
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -357,7 +358,7 @@ public class MetafixMethodTest {
 
     @Test
     public void parseTextEscapedGroups() {
-        Assertions.assertThrows(MetafactureException.class, () ->
+        assertThrows(IllegalArgumentException.class, "No group with name <c>", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "parse_text(data, '(?<a>.)(.)\\\\(?<c>.\\\\)')"
                 ),
@@ -368,14 +369,13 @@ public class MetafixMethodTest {
                 },
                 o -> {
                 }
-            ),
-            "No group with name <c>"
+            )
         );
     }
 
     @Test
     public void parseTextQuotedGroups() {
-        Assertions.assertThrows(MetafactureException.class, () ->
+        assertThrows(IllegalArgumentException.class, "No group with name <c>", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "parse_text(data, '(?<a>.)(.)\\\\Q(?<c>.)\\\\E')"
                 ),
@@ -386,8 +386,7 @@ public class MetafixMethodTest {
                 },
                 o -> {
                 }
-            ),
-            "No group with name <c>"
+            )
         );
     }
 
@@ -477,4 +476,11 @@ public class MetafixMethodTest {
                 o.get().endRecord();
             });
     }
+
+    private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
+        final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
+        Assertions.assertSame(expectedClass, exception.getClass());
+        Assertions.assertEquals(expectedMessage, exception.getMessage());
+    }
+
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -538,7 +538,6 @@ public class MetafixMethodTest {
     }
 
     @Test
-    // TODO: Fix order (`animals[].1` should stay before `animals[].2`)
     public void shouldAppendValueInArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "append('animals[].1', ' is cool')"
@@ -555,9 +554,9 @@ public class MetafixMethodTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("animals[]");
+                o.get().literal("1", "dog is cool");
                 o.get().literal("2", "cat");
                 o.get().literal("3", "zebra");
-                o.get().literal("1", "dog is cool");
                 o.get().endEntity();
                 o.get().endRecord();
             }
@@ -565,7 +564,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldAppendValueInEntireArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "append('animals[].*', ' is cool')"
@@ -709,7 +708,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldFilterArrayObjectValues() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "filter('animals[]', '[Cc]at')"
@@ -793,7 +792,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldJoinArrayObjectField() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "join_field('animals[]', ',')"
@@ -859,7 +858,6 @@ public class MetafixMethodTest {
     }
 
     @Test
-    // TODO: Fix order (`animals[].1` should stay before `animals[].2`)
     public void shouldPrependValueInArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "prepend('animals[].1', 'cool ')"
@@ -876,9 +874,9 @@ public class MetafixMethodTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("animals[]");
+                o.get().literal("1", "cool dog");
                 o.get().literal("2", "cat");
                 o.get().literal("3", "zebra");
-                o.get().literal("1", "cool dog");
                 o.get().endEntity();
                 o.get().endRecord();
             }
@@ -886,7 +884,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldPrependValueInEntireArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "prepend('animals[].*', 'cool ')"
@@ -958,7 +956,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldReplaceAllRegexesInArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "replace_all('animals[].*', a, QR)"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -16,15 +16,12 @@
 
 package org.metafacture.metafix;
 
-import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.StreamReceiver;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -46,212 +43,196 @@ public class MetafixMethodTest {
     }
 
     @Test
-    public void upcase() {
+    public void shouldUpcaseString() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "upcase('title')"),
+                "upcase('title')"
+            ),
             i -> {
                 i.startRecord("1");
-                i.endRecord();
-
-                i.startRecord("2");
                 i.literal("title", "marc");
-                i.literal("title", "json");
                 i.endRecord();
-
-                i.startRecord("3");
-                i.endRecord();
-            }, o -> {
+            },
+            o -> {
                 o.get().startRecord("1");
+                o.get().literal("title", "MARC");
                 o.get().endRecord();
-
-                o.get().startRecord("2");
-                o.get().startEntity("title");
-                o.get().literal("1", "MARC");
-                o.get().literal("2", "JSON");
-                o.get().endEntity();
-                o.get().endRecord();
-
-                o.get().startRecord("3");
-                o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
-    public void upcaseDotNotationNested() {
+    public void shouldUpcaseDotNotationNested() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "upcase('data.title')"),
+                "upcase('data.title')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("data");
                 i.literal("title", "marc");
-                i.literal("title", "json");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("data");
-                o.get().startEntity("title");
-                o.get().literal("1", "MARC");
-                o.get().literal("2", "JSON");
-                f.apply(2).endEntity();
+                o.get().literal("title", "MARC");
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
-    public void downcase() {
+    public void shouldDowncaseString() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "downcase('title')"),
+                "downcase('title')"
+            ),
             i -> {
                 i.startRecord("1");
+                i.literal("title", "MARC");
                 i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "marc");
+                o.get().endRecord();
+            }
+        );
+    }
 
-                i.startRecord("2");
+    @Test
+    public void shouldDowncaseStringsInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "downcase('title.*')"
+            ),
+            i -> {
+                i.startRecord("1");
                 i.literal("title", "MARC");
                 i.literal("title", "Json");
                 i.endRecord();
-
-                i.startRecord("3");
-                i.endRecord();
-            }, o -> {
+            },
+            o -> {
                 o.get().startRecord("1");
-                o.get().endRecord();
-
-                o.get().startRecord("2");
                 o.get().startEntity("title");
                 o.get().literal("1", "marc");
                 o.get().literal("2", "json");
                 o.get().endEntity();
                 o.get().endRecord();
-
-                o.get().startRecord("3");
-                o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
-    public void capitalize() {
+    public void shouldCapitalizeString() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "capitalize('title')"),
+                "capitalize('title')"
+            ),
             i -> {
                 i.startRecord("1");
+                i.literal("title", "marc");
                 i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "Marc");
+                o.get().endRecord();
+            }
+        );
+    }
 
-                i.startRecord("2");
+    @Test
+    public void shouldCapitalizeStringsInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "capitalize('title.*')"
+            ),
+            i -> {
+                i.startRecord("1");
                 i.literal("title", "marc");
                 i.literal("title", "json");
                 i.endRecord();
-
-                i.startRecord("3");
-                i.endRecord();
-            }, o -> {
+            },
+            o -> {
                 o.get().startRecord("1");
-                o.get().endRecord();
-
-                o.get().startRecord("2");
                 o.get().startEntity("title");
                 o.get().literal("1", "Marc");
                 o.get().literal("2", "Json");
                 o.get().endEntity();
                 o.get().endRecord();
-
-                o.get().startRecord("3");
-                o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
-    public void substring() {
+    public void shouldNotCapitalizeArray() {
+        MetafixTestHelpers.assertThrows(IllegalStateException.class, "expected String, got Array", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "capitalize('title')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("title", "marc");
+                    i.literal("title", "json");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldGetSubstringOfString() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "substring('title', '0', '2')"),
+                "substring('title', '0', '2')"
+            ),
             i -> {
                 i.startRecord("1");
-                i.endRecord();
-
-                i.startRecord("2");
                 i.literal("title", "marc");
-                i.literal("title", "json");
                 i.endRecord();
-
-                i.startRecord("3");
-                i.endRecord();
-            }, o -> {
+            },
+            o -> {
                 o.get().startRecord("1");
+                o.get().literal("title", "m");
                 o.get().endRecord();
-
-                o.get().startRecord("2");
-                o.get().startEntity("title");
-                o.get().literal("1", "m");
-                o.get().literal("2", "j");
-                o.get().endEntity();
-                o.get().endRecord();
-
-                o.get().startRecord("3");
-                o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
-    public void substringWithVar() {
+    public void shouldGetSubstringWithVar() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "substring('title', '0', '$[end]')"),
-                ImmutableMap.of("end", "3"),
+                "substring('title', '0', '$[end]')"
+            ),
+            ImmutableMap.of("end", "3"),
             i -> {
                 i.startRecord("1");
-                i.endRecord();
-
-                i.startRecord("2");
                 i.literal("title", "marc");
-                i.literal("title", "json");
                 i.endRecord();
-
-                i.startRecord("3");
-                i.endRecord();
-            }, o -> {
+            },
+            o -> {
                 o.get().startRecord("1");
+                o.get().literal("title", "ma");
                 o.get().endRecord();
-
-                o.get().startRecord("2");
-                o.get().startEntity("title");
-                o.get().literal("1", "ma");
-                o.get().literal("2", "js");
-                o.get().endEntity();
-                o.get().endRecord();
-
-                o.get().startRecord("3");
-                o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
-    public void trim() {
+    public void shouldTrimString() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "trim('title')"),
+                "trim('title')"
+            ),
             i -> {
                 i.startRecord("1");
-                i.endRecord();
-
-                i.startRecord("2");
                 i.literal("title", "  marc  ");
-                i.literal("title", "  json  ");
                 i.endRecord();
-
-                i.startRecord("3");
-                i.endRecord();
-            }, o -> {
+            },
+            o -> {
                 o.get().startRecord("1");
+                o.get().literal("title", "marc");
                 o.get().endRecord();
-
-                o.get().startRecord("2");
-                o.get().startEntity("title");
-                o.get().literal("1", "marc");
-                o.get().literal("2", "json");
-                o.get().endEntity();
-                o.get().endRecord();
-
-                o.get().startRecord("3");
-                o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -353,7 +334,7 @@ public class MetafixMethodTest {
 
     @Test
     public void parseTextEscapedGroups() {
-        assertThrows(IllegalArgumentException.class, "No group with name <c>", () ->
+        MetafixTestHelpers.assertThrows(IllegalArgumentException.class, "No group with name <c>", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "parse_text(data, '(?<a>.)(.)\\\\(?<c>.\\\\)')"
                 ),
@@ -370,7 +351,7 @@ public class MetafixMethodTest {
 
     @Test
     public void parseTextQuotedGroups() {
-        assertThrows(IllegalArgumentException.class, "No group with name <c>", () ->
+        MetafixTestHelpers.assertThrows(IllegalArgumentException.class, "No group with name <c>", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "parse_text(data, '(?<a>.)(.)\\\\Q(?<c>.)\\\\E')"
                 ),
@@ -591,36 +572,31 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldNotAppendValueToArray() {
-        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "append('animals[]', ' is cool')"
-            ),
-            i -> {
-                i.startRecord("1");
-                i.startEntity("animals[]");
-                i.literal("1", "dog");
-                i.literal("2", "cat");
-                i.literal("3", "zebra");
-                i.endEntity();
-                i.endRecord();
-            },
-            o -> {
-                o.get().startRecord("1");
-                o.get().startEntity("animals[]");
-                o.get().literal("1", "dog");
-                o.get().literal("2", "cat");
-                o.get().literal("3", "zebra");
-                o.get().endEntity();
-                o.get().endRecord();
-            }
+        MetafixTestHelpers.assertThrows(IllegalStateException.class, "expected String, got Array", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "append('animals[]', ' is cool')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("animals[]");
+                    i.literal("1", "dog");
+                    i.literal("2", "cat");
+                    i.literal("3", "zebra");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
         );
     }
 
     @Test
     // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldNotAppendValueToHash() {
-        assertThrows(IllegalStateException.class, "expected String, got Hash", () ->
+        MetafixTestHelpers.assertThrows(IllegalStateException.class, "expected String, got Hash", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "append('animals', ' is cool')"
                 ),
@@ -933,29 +909,24 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldNotPrependValueToArray() {
-        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "prepend('animals[]', 'cool ')"
-            ),
-            i -> {
-                i.startRecord("1");
-                i.startEntity("animals[]");
-                i.literal("1", "dog");
-                i.literal("2", "cat");
-                i.literal("3", "zebra");
-                i.endEntity();
-                i.endRecord();
-            },
-            o -> {
-                o.get().startRecord("1");
-                o.get().startEntity("animals[]");
-                o.get().literal("1", "dog");
-                o.get().literal("2", "cat");
-                o.get().literal("3", "zebra");
-                o.get().endEntity();
-                o.get().endRecord();
-            }
+        MetafixTestHelpers.assertThrows(IllegalStateException.class, "expected String, got Array", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "prepend('animals[]', 'cool ')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("animals[]");
+                    i.literal("1", "dog");
+                    i.literal("2", "cat");
+                    i.literal("3", "zebra");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
         );
     }
 
@@ -1098,7 +1069,7 @@ public class MetafixMethodTest {
 
     @Test
     public void shouldFailToSortNumericallyWithInvalidNumber() {
-        assertThrows(NumberFormatException.class, "For input string: \"x\"", () ->
+        MetafixTestHelpers.assertThrows(NumberFormatException.class, "For input string: \"x\"", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "sort_field(numbers, numeric: 'true')"
                 ),
@@ -1348,12 +1319,6 @@ public class MetafixMethodTest {
                 o.get().endRecord();
             }
         );
-    }
-
-    private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
-        final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
-        Assertions.assertSame(expectedClass, exception.getClass());
-        Assertions.assertEquals(expectedMessage, exception.getMessage());
     }
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -643,6 +643,24 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldReplaceAllRegexes() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "replace_all(title, '[aei]', 'X')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "metafix");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "mXtXfXx");
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -661,6 +661,46 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldReverseString() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "reverse(title)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "metafix");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "xifatem");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldReverseArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "reverse(title)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "marc");
+                i.literal("title", "json");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("title");
+                o.get().literal("1", "json");
+                o.get().literal("2", "marc");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -477,6 +477,28 @@ public class MetafixMethodTest {
             });
     }
 
+    @Test
+    public void shouldDoNothing() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "nothing()"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "marc");
+                i.literal("title", "json");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("title");
+                o.get().literal("1", "marc");
+                o.get().literal("2", "json");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -517,6 +517,48 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldCountNumberOfValuesInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "count(numbers)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "41");
+                i.literal("numbers", "42");
+                i.literal("numbers", "6");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("numbers", "4");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldCountNumberOfValuesInHash() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "count(person)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("person");
+                i.literal("name", "François");
+                i.literal("age", "12");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("person", "2");
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -625,6 +625,24 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldPrependValue() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "prepend(title, 'I love ')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "metafix");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "I love metafix");
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -499,6 +499,24 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldAppendValue() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "append(title, ' ?!')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "metafix");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("title", "metafix ?!");
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -946,6 +946,33 @@ public class MetafixMethodTest {
     }
 
     @Test
+    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldReplaceAllRegexesInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "replace_all('animals[].*', a, QR)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cQRt");
+                o.get().literal("3", "zebrQR");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldReverseString() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "reverse(title)"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -781,6 +781,29 @@ public class MetafixMethodTest {
     }
 
     @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldJoinArrayObjectField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "join_field('animals[]', ',')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("animals[]", "dog,cat,zebra");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldPrependValue() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "prepend(title, 'I love ')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -559,6 +559,54 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldFilterArrayValues() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "filter(animals, '[Cc]at')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animals", "Lion");
+                i.literal("animals", "Cat");
+                i.literal("animals", "Tiger");
+                i.literal("animals", "Bobcat");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals");
+                o.get().literal("1", "Cat");
+                o.get().literal("2", "Bobcat");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldFilterArrayValuesInverted() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "filter(animals, '[Cc]at', invert: 'true')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animals", "Lion");
+                i.literal("animals", "Cat");
+                i.literal("animals", "Tiger");
+                i.literal("animals", "Bobcat");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals");
+                o.get().literal("1", "Lion");
+                o.get().literal("2", "Tiger");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -715,6 +715,33 @@ public class MetafixMethodTest {
     }
 
     @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldFilterArrayObjectValues() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "filter('animals[]', '[Cc]at')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "Lion");
+                i.literal("2", "Cat");
+                i.literal("3", "Tiger");
+                i.literal("4", "Bobcat");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "Cat");
+                o.get().literal("2", "Bobcat");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldGetIndexOfSubstring() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "index(title, 't')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -822,6 +822,112 @@ public class MetafixMethodTest {
     }
 
     @Test
+    // TODO: Fix order (`animols.name` should stay before `animols.type`)
+    public void shouldPrependValueInHash() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "prepend(animols.name, 'nice ')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animols");
+                i.literal("name", "bird");
+                i.literal("type", "TEST");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animols");
+                o.get().literal("type", "TEST");
+                o.get().literal("name", "nice bird");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    // TODO: Fix order (`animals[].1` should stay before `animals[].2`)
+    public void shouldPrependValueInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "prepend('animals[].1', 'cool ')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().literal("1", "cool dog");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldPrependValueInEntireArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "prepend('animals[].*', 'cool ')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "cool dog");
+                o.get().literal("2", "cool cat");
+                o.get().literal("3", "cool zebra");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldNotPrependValueToArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "prepend('animals[]', 'cool ')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "cat");
+                i.literal("3", "zebra");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldReplaceAllRegexes() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "replace_all(title, '[aei]', 'X')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -850,6 +850,88 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldSplitStringField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "split_field(date, '-')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("date", "1918-17-16");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("date");
+                o.get().literal("1", "1918");
+                o.get().literal("2", "17");
+                o.get().literal("3", "16");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldSplitArrayField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "split_field(date, '-')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("date", "1918-17-16");
+                i.literal("date", "2021-22-23");
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("date");
+                o.get().startEntity("1");
+                o.get().literal("1", "1918");
+                o.get().literal("2", "17");
+                o.get().literal("3", "16");
+                o.get().endEntity();
+                o.get().startEntity("2");
+                o.get().literal("1", "2021");
+                o.get().literal("2", "22");
+                o.get().literal("3", "23");
+                f.apply(2).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldSplitHashField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "split_field(date, '-')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("date");
+                i.literal("a", "1918-17-16");
+                i.literal("b", "2021-22-23");
+                i.endEntity();
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("date");
+                o.get().startEntity("a");
+                o.get().literal("1", "1918");
+                o.get().literal("2", "17");
+                o.get().literal("3", "16");
+                o.get().endEntity();
+                o.get().startEntity("b");
+                o.get().literal("1", "2021");
+                o.get().literal("2", "22");
+                o.get().literal("3", "23");
+                f.apply(2).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -618,6 +618,28 @@ public class MetafixMethodTest {
     }
 
     @Test
+    // See https://github.com/metafacture/metafacture-fix/issues/100
+    public void shouldNotAppendValueToHash() {
+        assertThrows(IllegalStateException.class, "expected String, got Hash", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "append('animals', ' is cool')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("animals");
+                    i.literal("1", "dog");
+                    i.literal("2", "cat");
+                    i.literal("3", "zebra");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
     public void shouldCountNumberOfValuesInArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "count(numbers)"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -932,6 +932,27 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldSumNumbers() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "sum(numbers)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "41");
+                i.literal("numbers", "42");
+                i.literal("numbers", "6");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("numbers", "95");
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -953,6 +953,31 @@ public class MetafixMethodTest {
         );
     }
 
+    @Test
+    public void shouldRemoveDuplicates() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "uniq(numbers)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("numbers", "41");
+                i.literal("numbers", "42");
+                i.literal("numbers", "6");
+                i.literal("numbers", "6");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("numbers");
+                o.get().literal("1", "41");
+                o.get().literal("2", "42");
+                o.get().literal("3", "6");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
     private void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
         Assertions.assertSame(expectedClass, exception.getClass());

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -742,6 +742,24 @@ public class MetafixMethodTest {
     }
 
     @Test
+    public void shouldGetFirstIndexOfSubstring() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "index(animal, 'n')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animal", "bunny");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("animal", "2");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldGetIndexOfSubstring() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "index(title, 't')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1907,7 +1907,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldRecursivelyRenameFieldsInHash() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "rename(others, ani, QR)"
@@ -1937,7 +1937,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldRecursivelyRenameFieldsInArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "rename('animals[]', ani, XY)"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1767,4 +1767,26 @@ public class MetafixRecordTest {
         );
     }
 
+    @Test
+    public void shouldRenameFieldsInHash() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "rename(your, '[ae]', X)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("your");
+                i.literal("name", "nicolas");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("your");
+                o.get().literal("nXmX", "nicolas");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1855,6 +1855,32 @@ public class MetafixRecordTest {
     }
 
     @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldAddRandomNumberToUnmarkedArrayObject() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "random('animals.$append', '100')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals");
+                i.literal("1", "cat");
+                i.literal("2", "dog");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals");
+                o.get().literal("1", "cat");
+                o.get().literal("2", "dog");
+                o.get().literal(ArgumentMatchers.eq("3"), ArgumentMatchers.argThat(i -> Integer.parseInt(i) < 100));
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldRenameFieldsInHash() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "rename(your, '[ae]', X)"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1813,6 +1813,7 @@ public class MetafixRecordTest {
     @Test
     public void shouldAddObjectWithRandomNumberToMarkedArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('bnimals[]')",
                 "random('bnimals[].$append.number', '100')"
             ),
             i -> {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -1741,6 +1742,29 @@ public class MetafixRecordTest {
                 f.apply(2).endEntity();
                 o.get().endRecord();
             });
+    }
+
+    @Test
+    public void shouldAddRandomNumber() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "random(test, '100')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "marc");
+                i.literal("title", "json");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("title");
+                o.get().literal("1", "marc");
+                o.get().literal("2", "json");
+                o.get().endEntity();
+                o.get().literal(ArgumentMatchers.eq("test"), ArgumentMatchers.argThat(i -> Integer.parseInt(i) < 100));
+                o.get().endRecord();
+            }
+        );
     }
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1768,7 +1768,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldReplaceExistingValueWithRandomNumber() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "random(others, '100')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1876,4 +1876,111 @@ public class MetafixRecordTest {
         );
     }
 
+    @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldRecursivelyRenameFieldsInHash() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "rename(others, ani, QR)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("others");
+                i.literal("animal", "human");
+                i.literal("canister", "metall");
+                i.startEntity("area");
+                i.literal("ani", "test");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("others");
+                o.get().literal("QRmal", "human");
+                o.get().literal("cQRster", "metall");
+                o.get().startEntity("area");
+                o.get().literal("QR", "test");
+                f.apply(2).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldRecursivelyRenameFieldsInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "rename('animals[]', ani, XY)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.startEntity("1");
+                i.literal("animal", "dog");
+                i.endEntity();
+                i.startEntity("2");
+                i.literal("animal", "cat");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().startEntity("1");
+                o.get().literal("XYmal", "dog");
+                o.get().endEntity();
+                o.get().startEntity("2");
+                o.get().literal("XYmal", "cat");
+                f.apply(2).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    public void shouldRenameAllFieldsInHash() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "rename('.', ani, XY)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals");
+                i.literal("animal", "dog");
+                i.literal("animal", "cat");
+                i.endEntity();
+                i.startEntity("others");
+                i.literal("animal", "human");
+                i.literal("canister", "metall");
+                i.startEntity("area");
+                i.literal("ani", "test");
+                i.endEntity();
+                i.endEntity();
+                i.startEntity("fictional");
+                i.literal("animal", "unicorn");
+                i.endEntity();
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("XYmals");
+                o.get().startEntity("XYmal");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                f.apply(2).endEntity();
+                o.get().startEntity("others");
+                o.get().literal("XYmal", "human");
+                o.get().literal("cXYster", "metall");
+                o.get().startEntity("area");
+                o.get().literal("XY", "test");
+                f.apply(2).endEntity();
+                o.get().startEntity("fictional");
+                o.get().literal("XYmal", "unicorn");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
@@ -127,6 +127,11 @@ public class MetafixScriptTest {
         assertMap("put_filemap('" + TSV_MAP + "', '" + MAP_NAME + "', sep_char: '\t')", MAP_NAME);
     }
 
+    @Test
+    public void shouldDoNothing() {
+        assertFix("nothing()", f -> { });
+    }
+
     private void assertVar(final String fixDef, final Map<String, String> vars, final Map<String, String> result) {
         assertFix(fixDef, vars, f -> result.forEach((k, v) -> Assertions.assertEquals(v, f.getVars().get(k))));
     }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
@@ -16,9 +16,11 @@
 
 package org.metafacture.metafix;
 
+import org.metafacture.framework.MetafactureException;
 import org.metafacture.framework.StreamReceiver;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoAssertionError;
@@ -41,6 +43,12 @@ import java.util.function.Supplier;
 public final class MetafixTestHelpers {
 
     private MetafixTestHelpers() {
+    }
+
+    public static void assertThrows(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
+        final Throwable exception = Assertions.assertThrows(MetafactureException.class, executable).getCause();
+        Assertions.assertSame(expectedClass, exception.getClass());
+        Assertions.assertEquals(expectedMessage, exception.getMessage());
     }
 
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Consumer<Metafix> in,

--- a/metafix/src/test/java/org/metafacture/metafix/ValueTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/ValueTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.metafix;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+public class ValueTest {
+
+    public ValueTest() {
+    }
+
+    @Test
+    public void shouldSatisfyEqualsContract() {
+        EqualsVerifier.forClass(Value.class)
+            .withPrefabValues(Value.class, Value.newArray(), Value.newHash())
+            .withPrefabValues(Value.Hash.class, Value.newHash().asHash(), Value.newHash(h -> h.put("k", new Value("v"))).asHash())
+            .verify();
+    }
+
+}


### PR DESCRIPTION
I've opted for the non-destructive approach w.r.t. `Value`s. I don't think we're consistent as to when we modify an existing value and when we create a new one. Let me know if you have a preference - or if I'm mistaken and there's indeed a system to it ;)

Omitted Fix functions from the [cheat sheet](https://librecat.org/assets/catmandu_cheat_sheet.pdf):

* `assoc()`
* `diassoc()`
* `compact()` (not applicable)
* `flatten()`
* `from_json()`
* `to_json()`
* `uri_decode()`
* `uri_encode()`

Resolves #100.