### PR TITLE
Upgrade xtext dependency to 2.26.0.M2 (prerelease).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
       'mockito':        '2.27.0',
       'requirejs':      '2.3.6',
       'slf4j':          '1.7.21',
-      'xtext':          '2.17.0',
+      'xtext':          '2.26.0.M2',
       'guava':          '29.0-jre'
     ]
   }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -21,10 +21,7 @@ import org.metafacture.framework.StreamReceiver;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -36,9 +33,6 @@ import java.util.Arrays;
  */
 @ExtendWith(MockitoExtension.class)
 public class MetafixBindTest {
-
-    @RegisterExtension
-    private MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private StreamReceiver streamReceiver;

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -21,10 +21,7 @@ import org.metafacture.framework.StreamReceiver;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -36,9 +33,6 @@ import java.util.Arrays;
  */
 @ExtendWith(MockitoExtension.class)
 public class MetafixIfTest {
-
-    @RegisterExtension
-    private MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private StreamReceiver streamReceiver;

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -22,10 +22,7 @@ import org.metafacture.metamorph.api.MorphExecutionException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -41,9 +38,6 @@ public class MetafixLookupTest {
 
     private static final String CSV_MAP = "src/test/resources/org/metafacture/metafix/maps/test.csv";
     private static final String TSV_MAP = "src/test/resources/org/metafacture/metafix/maps/test.tsv";
-
-    @RegisterExtension
-    private MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private StreamReceiver streamReceiver;

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -23,10 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -39,9 +36,6 @@ import java.util.Arrays;
  */
 @ExtendWith(MockitoExtension.class)
 public class MetafixMethodTest {
-
-    @RegisterExtension
-    private MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private StreamReceiver streamReceiver;

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -23,10 +23,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -39,9 +36,6 @@ import java.util.Arrays;
  */
 @ExtendWith(MockitoExtension.class)
 public class MetafixRecordTest {
-
-    @RegisterExtension
-    private MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private StreamReceiver streamReceiver;

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixSelectorTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixSelectorTest.java
@@ -21,10 +21,7 @@ import org.metafacture.framework.StreamReceiver;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -38,9 +35,6 @@ import java.util.Arrays;
 @ExtendWith(MockitoExtension.class)
 @Disabled("TODO: support Fix-style selectors https://github.com/LibreCat/Catmandu/wiki/Selectors")
 public final class MetafixSelectorTest {
-
-    @RegisterExtension
-    private MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private StreamReceiver streamReceiver;


### PR DESCRIPTION
For Java 17 support (required in Limetrans); see eclipse/xtext#1982.