### PR TITLE
Convert marked array entity into actual array object.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -189,7 +189,9 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
             throw new IllegalArgumentException("Entity name must not be null.");
         }
 
-        final Value value = Value.newHash();
+        final Value value = name.endsWith(ARRAY_MARKER) ? Value.newArray() : Value.newHash();
+        // TODO: Remove array marker? => name.substring(0, name.length() - ARRAY_MARKER.length());
+
         addValue(name, value);
         entities.add(value);
 

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -77,7 +77,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     private int entityCount;
     private StreamReceiver outputStreamReceiver;
     private String recordIdentifier;
-    private List<Value.Hash> entities = new ArrayList<>();
+    private List<Value> entities = new ArrayList<>();
 
     public Metafix() {
         flattener.setReceiver(new DefaultStreamReceiver() {
@@ -170,20 +170,31 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
         });
     }
 
+    private void addValue(final String name, final Value value) {
+        final int index = entityCountStack.peek() - 1;
+        if (index < 0 || entities.size() <= index) {
+            currentRecord.add(name, value);
+        }
+        else {
+            entities.get(index).matchType()
+                .ifArray(a -> a.add(value))
+                .ifHash(h -> h.add(name, value))
+                .orElseThrow();
+        }
+    }
+
     @Override
     public void startEntity(final String name) {
         if (name == null) {
             throw new IllegalArgumentException("Entity name must not be null.");
         }
-        ++entityCount;
-        final Integer currentEntityIndex = entityCountStack.peek() - 1;
-        final Value.Hash previousEntity = currentEntityIndex < 0 ||
-                entities.size() <= currentEntityIndex ? null : entities.get(currentEntityIndex);
-        entityCountStack.push(Integer.valueOf(entityCount));
-        flattener.startEntity(name);
+
         final Value value = Value.newHash();
-        (previousEntity != null ? previousEntity : currentRecord).add(name, value);
-        entities.add(value.asHash());
+        addValue(name, value);
+        entities.add(value);
+
+        entityCountStack.push(Integer.valueOf(++entityCount));
+        flattener.startEntity(name);
     }
 
     @Override
@@ -195,10 +206,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     @Override
     public void literal(final String name, final String value) {
         LOG.debug("Putting '{}': '{}'", name, value);
-        final Integer currentEntityIndex = entityCountStack.peek() - 1;
-        final Value.Hash currentEntity = currentEntityIndex < 0 ||
-                entities.size() <= currentEntityIndex ? null : entities.get(currentEntityIndex);
-        (currentEntity != null ? currentEntity : currentRecord).add(name, new Value(value));
+        addValue(name, new Value(value));
         // TODO: keep flattener as option?
         // flattener.literal(name, value);
     }

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -305,21 +305,6 @@ public class Value {
                 void apply(final Hash hash, final String field, final Value value) {
                     hash.add(field, value);
                 }
-            },
-            /* For an indexed representation of arrays as hashes with 1, 2, 3 etc. keys.
-             * i.e. ["a", "b", "c"] as { "1":"a", "2":"b", "3": "c" }
-             * This is what is produced by JsonDecoder and Metafix itself for arrays.
-             * TODO? maybe this would be a good general internal representation, resulting
-             * in every value being either a hash or a string, no more separate array type.*/
-            INDEXED {
-                @Override
-                void apply(final Hash hash, final String field, final Value value) {
-                    hash.add(nextIndex(hash), field.equals(ReservedField.$append.name()) ? value : newHash(h -> h.put(field, value)));
-                }
-
-                private String nextIndex(final Hash hash) {
-                    return "" + (hash.size() + 1) /* TODO? check if keys are actually all ints? */;
-                }
             };
 
             abstract void apply(Hash hash, String field, Value value);
@@ -697,7 +682,7 @@ public class Value {
                     // TODO: move impl into enum elements, here call only value.insert
                     value.matchType()
                         .ifArray(a -> a.insert(mode, tail, newValue))
-                        .ifHash(h -> h.insert(insertMode(mode, field, tail), tail, newValue))
+                        .ifHash(h -> h.insert(mode, tail, newValue))
                         .orElseThrow();
                 }
             }
@@ -708,7 +693,7 @@ public class Value {
         private Value processRef(final InsertMode mode, final Value newValue, final String field, final String[] tail) {
             final Value referencedValue = getReferencedValue(field);
             if (referencedValue != null) {
-                return referencedValue.asHash().insert(insertMode(mode, field, tail), tail, newValue);
+                return referencedValue.asHash().insert(mode, tail, newValue);
             }
             else {
                 throw new IllegalArgumentException("Using ref, but can't find: " + field + " in: " + this);
@@ -736,16 +721,6 @@ public class Value {
                     break;
             }
             return referencedValue;
-        }
-
-        private InsertMode insertMode(final InsertMode mode, final String field, final String[] tail) {
-            // if the field is marked as array, this hash should be smth. like { 1=a, 2=b }
-            final boolean isIndexedArray = field.endsWith(Metafix.ARRAY_MARKER);
-            final boolean nextIsRef = tail.length > 0 && (
-                    tail[0].startsWith(ReservedField.$first.name()) ||
-                    tail[0].startsWith(ReservedField.$last.name()) ||
-                    isNumber(tail[0]));
-            return isIndexedArray && !nextIsRef ? InsertMode.INDEXED : mode;
         }
 
         /**

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -477,6 +477,7 @@ public class MetafixRecordTest {
     @Test
     public void appendWithWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('stringimals[]')",
                 "copy_field('?nimal', 'stringimals[].$append')"
             ),
             i -> {
@@ -542,6 +543,7 @@ public class MetafixRecordTest {
     @Test
     public void appendWithMultipleWildcards() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('stringimals[]')",
                 "copy_field('?ni??l', 'stringimals[].$append')"
             ),
             i -> {
@@ -572,6 +574,7 @@ public class MetafixRecordTest {
     @Test
     public void appendWithAsteriksWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('stringimals[]')",
                 "copy_field('*al', 'stringimals[].$append')"
             ),
             i -> {
@@ -601,6 +604,7 @@ public class MetafixRecordTest {
     @Test
     public void appendWithBracketWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('stringimals[]')",
                 "copy_field('[ac]nimal', 'stringimals[].$append')"
             ),
             i -> {
@@ -630,6 +634,7 @@ public class MetafixRecordTest {
     // See https://github.com/metafacture/metafacture-fix/issues/89
     public void appendWithAsteriksWildcardAtTheEnd() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('stringimals[]')",
                 "copy_field('ani*', 'stringimals[].$append')"
             ),
             i -> {


### PR DESCRIPTION
The last commit (7d9b2a4) might be debatable; but I feel making intentions explicit works in our favor for now (the usual WDCD applies, though).

Note that I deliberately went in the direction of more explicit types instead of less:

> TODO? maybe this would be a good general internal representation, resulting
> in every value being either a hash or a string, no more separate array type.

Resolves #109 and fixes most of the array issues in #100 (see 11d1e71).