### PR TITLE
Fix `exists()` Fix conditional with nested paths.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixConditional.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixConditional.java
@@ -64,7 +64,7 @@ public enum FixConditional implements FixPredicate {
     exists {
         @Override
         public boolean test(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-            return record.containsField(params.get(0));
+            return record.containsPath(params.get(0));
         }
     },
 

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -593,6 +593,37 @@ public class Value {
             return matchFields(field, Stream::anyMatch);
         }
 
+        public boolean containsPath(final String fieldPath) {
+            final String[] path = split(fieldPath);
+            final String field = path[0];
+
+            final boolean containsField = containsField(field);
+            final boolean containsPath;
+
+            if (containsField && path.length > 1) {
+                final Value value;
+
+                try {
+                    value = find(path);
+                }
+                catch (final MetafactureException e) {
+                    if (e.getCause() instanceof IllegalStateException) {
+                        return false;
+                    }
+                    else {
+                        throw e;
+                    }
+                }
+
+                containsPath = !isNull(value);
+            }
+            else {
+                containsPath = containsField;
+            }
+
+            return containsPath;
+        }
+
         /**
          * Checks whether this hash is empty.
          *

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1451,13 +1451,16 @@ public class MetafixRecordTest {
     @Test
     public void reject() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "if exists ('_metadata.error')",
+                "if exists('_metadata.error')",
                 "  reject()",
                 "end"),
             i -> {
                 i.startRecord("1");
-                i.literal("_metadata.error", "details");
+                i.startEntity("_metadata");
+                i.literal("error", "details");
+                i.endEntity();
                 i.endRecord();
+
                 i.startRecord("2");
                 i.endRecord();
             }, o -> {


### PR DESCRIPTION
NOTE: There's a (minor) compatibility break in `MetafixRecordTest.reject()`.

Resolves #117.