### PR TITLE
Emit indexed arrays only if marked.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -171,7 +171,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
 
     private void emit(final String field, final Value value) {
         Value.asList(value, array -> {
-            final boolean isMulti = array.size() > 1 || value.isArray();
+            final boolean isMulti = isArrayName(field);
             if (isMulti) {
                 outputStreamReceiver.startEntity(field);
             }
@@ -196,6 +196,10 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
         });
     }
 
+    private boolean isArrayName(final String name) {
+        return name.endsWith(ARRAY_MARKER);
+    }
+
     private void addValue(final String name, final Value value) {
         final int index = entityCountStack.peek() - 1;
         if (index < 0 || entities.size() <= index) {
@@ -215,8 +219,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
             throw new IllegalArgumentException("Entity name must not be null.");
         }
 
-        final Value value = name.endsWith(ARRAY_MARKER) ? Value.newArray() : Value.newHash();
-        // TODO: Remove array marker? => name.substring(0, name.length() - ARRAY_MARKER.length());
+        final Value value = isArrayName(name) ? Value.newArray() : Value.newHash();
 
         addValue(name, value);
         entities.add(value);

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -25,7 +25,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
-import java.util.stream.IntStream;
 
 /**
  * Test Metafix binds.
@@ -57,10 +56,8 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("author");
-                o.get().literal("1", "A UNIVERSITY");
-                o.get().literal("2", "MAX");
-                o.get().endEntity();
+                o.get().literal("author", "A UNIVERSITY");
+                o.get().literal("author", "MAX");
                 o.get().endRecord();
             });
     }
@@ -101,7 +98,8 @@ public class MetafixBindTest {
                 "do list('path':'foo','var':'loop')",
                 " copy_field('test','loop.baz')",
                 " copy_field('loop.bar','loop.qux')",
-                "end"),
+                "end"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("foo");
@@ -112,22 +110,23 @@ public class MetafixBindTest {
                 i.endEntity();
                 i.literal("test", "42");
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("foo");
-                o.get().startEntity("1");
                 o.get().literal("bar", "1");
                 o.get().literal("baz", "42");
                 o.get().literal("qux", "1");
-                f.apply(1).endEntity();
-                o.get().startEntity("2");
+                o.get().endEntity();
+                o.get().startEntity("foo");
                 o.get().literal("bar", "2");
                 o.get().literal("baz", "42");
                 o.get().literal("qux", "2");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().literal("test", "42");
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -136,7 +135,8 @@ public class MetafixBindTest {
                 "do list('path':'foo')",
                 " copy_field('test','baz')",
                 " copy_field('bar','qux')",
-                "end"),
+                "end"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("foo");
@@ -147,20 +147,21 @@ public class MetafixBindTest {
                 i.endEntity();
                 i.literal("test", "42");
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("foo");
-                o.get().startEntity("1");
                 o.get().literal("bar", "1");
                 o.get().literal("qux", "1");
-                f.apply(1).endEntity();
-                o.get().startEntity("2");
+                o.get().endEntity();
+                o.get().startEntity("foo");
                 o.get().literal("bar", "2");
                 o.get().literal("qux", "2");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().literal("test", "42");
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -181,10 +182,8 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("author");
-                o.get().literal("1", "A UNIVERSITY");
-                o.get().literal("2", "MAX");
-                o.get().endEntity();
+                o.get().literal("author", "A UNIVERSITY");
+                o.get().literal("author", "MAX");
                 o.get().endRecord();
             });
     }
@@ -242,10 +241,8 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("author");
-                o.get().literal("1", "A UNIVERSITY");
-                o.get().literal("2", "MAX");
-                o.get().endEntity();
+                o.get().literal("author", "A UNIVERSITY");
+                o.get().literal("author", "MAX");
                 o.get().endRecord();
             });
     }
@@ -406,10 +403,8 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("author");
-                o.get().literal("1", "A University");
-                o.get().literal("2", "Max");
-                o.get().endEntity();
+                o.get().literal("author", "A University");
+                o.get().literal("author", "Max");
                 o.get().endRecord();
             });
     }
@@ -589,11 +584,9 @@ public class MetafixBindTest {
                 i.literal("nome", "Max");
                 i.endRecord();
             },
-            o -> {
+            (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("trace");
-                IntStream.range(0, expectedCount).forEach(i -> o.get().literal(String.valueOf(i + 1), "true"));
-                o.get().endEntity();
+                f.apply(expectedCount).literal("trace", "true");
                 o.get().endRecord();
             }
         );

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -62,18 +62,14 @@ public class MetafixIfTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "A University");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "A University");
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "Max");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "Max");
                 o.get().endRecord();
 
                 o.get().startRecord("3");
@@ -102,17 +98,13 @@ public class MetafixIfTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "A University");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "A University");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name");
-                o.get().literal("1", "Great University");
-                o.get().literal("2", "A University");
-                o.get().endEntity();
+                o.get().literal("name", "Great University");
+                o.get().literal("name", "A University");
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
 
@@ -126,7 +118,8 @@ public class MetafixIfTest {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "if none_contain('author.name', 'University')",
                 "  add_field('type', 'Person')",
-                "end"),
+                "end"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("author");
@@ -144,28 +137,28 @@ public class MetafixIfTest {
 
                 i.startRecord("3");
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "A University");
-                f.apply(2).endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "A University");
+                o.get().endEntity();
                 o.get().endRecord();
 
                 o.get().startRecord("2");
                 o.get().startEntity("author");
-                o.get().startEntity("name");
-                o.get().literal("1", "Max");
-                o.get().literal("2", "Mary");
-                f.apply(2).endEntity();
+                o.get().literal("name", "Max");
+                o.get().literal("name", "Mary");
+                o.get().endEntity();
                 o.get().literal("type", "Person");
                 o.get().endRecord();
 
                 o.get().startRecord("3");
                 o.get().literal("type", "Person");
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -281,10 +274,8 @@ public class MetafixIfTest {
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name");
-                o.get().literal("1", "Some University");
-                o.get().literal("2", "Filibandrina");
-                o.get().endEntity();
+                o.get().literal("name", "Some University");
+                o.get().literal("name", "Filibandrina");
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
             });
@@ -308,17 +299,13 @@ public class MetafixIfTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "Max");
-                o.get().literal("2", "A University");
-                o.get().endEntity();
+                o.get().literal("name", "Max");
+                o.get().literal("name", "A University");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name");
-                o.get().literal("1", "Some University");
-                o.get().literal("2", "University Filibandrina");
-                o.get().endEntity();
+                o.get().literal("name", "Some University");
+                o.get().literal("name", "University Filibandrina");
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
             });
@@ -567,10 +554,8 @@ public class MetafixIfTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "University");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "University");
                 o.get().literal("nome", "Max");
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
@@ -616,13 +601,11 @@ public class MetafixIfTest {
                 i.endEntity();
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("data");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "University");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "University");
                 o.get().literal("nome", "Max");
                 o.get().literal("type", "Organization");
                 o.get().endEntity();
@@ -673,10 +656,8 @@ public class MetafixIfTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("data");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "University");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "University");
                 o.get().literal("nome", "Max");
                 o.get().literal("type", "Organization");
                 o.get().endEntity();
@@ -734,10 +715,8 @@ public class MetafixIfTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "A University");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "A University");
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
 
@@ -788,13 +767,12 @@ public class MetafixIfTest {
                 i.startRecord("4");
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("data");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "A University");
-                f.apply(2).endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "A University");
+                o.get().endEntity();
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
 
@@ -907,18 +885,14 @@ public class MetafixIfTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "A University");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "A University");
                 o.get().literal("type", "Organization");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
-                o.get().startEntity("name");
-                o.get().literal("1", "Mary");
-                o.get().literal("2", "Max");
-                o.get().endEntity();
+                o.get().literal("name", "Mary");
+                o.get().literal("name", "Max");
                 o.get().endRecord();
 
                 o.get().startRecord("3");

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -77,14 +77,13 @@ public class MetafixLookupTest {
                 i.endEntity();
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("data");
-                o.get().startEntity("title");
-                o.get().literal("1", "Alohaeha");
-                o.get().literal("2", "Moin zäme");
-                o.get().literal("3", "Tach");
-                f.apply(2).endEntity();
+                o.get().literal("title", "Alohaeha");
+                o.get().literal("title", "Moin zäme");
+                o.get().literal("title", "Tach");
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -228,8 +227,6 @@ public class MetafixLookupTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -248,13 +245,9 @@ public class MetafixLookupTest {
                 i.literal("title", "Hey");
                 i.endRecord();
             },
-            o -> {
+            (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().literal("1", "Tach");
-                o.get().literal("2", "Tach");
-                o.get().literal("3", "Tach");
-                o.get().endEntity();
+                f.apply(3).literal("title", "Tach");
                 o.get().endRecord();
             }
         );
@@ -290,11 +283,9 @@ public class MetafixLookupTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().literal("1", "Alohaeha");
-                o.get().literal("2", "Moin zäme");
-                o.get().literal("3", "Tach");
-                o.get().endEntity();
+                o.get().literal("title", "Alohaeha");
+                o.get().literal("title", "Moin zäme");
+                o.get().literal("title", "Tach");
                 o.get().endRecord();
             }
         );

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -113,10 +113,8 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().literal("1", "marc");
-                o.get().literal("2", "json");
-                o.get().endEntity();
+                o.get().literal("title", "marc");
+                o.get().literal("title", "json");
                 o.get().endRecord();
             }
         );
@@ -153,10 +151,8 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().literal("1", "Marc");
-                o.get().literal("2", "Json");
-                o.get().endEntity();
+                o.get().literal("title", "Marc");
+                o.get().literal("title", "Json");
                 o.get().endRecord();
             }
         );
@@ -246,9 +242,7 @@ public class MetafixMethodTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("number");
-                o.get().literal("1", "41   : 15");
-                o.get().endEntity();
+                o.get().literal("number", "41   : 15");
                 o.get().endRecord();
             });
     }
@@ -263,11 +257,9 @@ public class MetafixMethodTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("date");
-                o.get().literal("1", "2015");
-                o.get().literal("2", "03");
-                o.get().literal("3", "07");
-                o.get().endEntity();
+                o.get().literal("date", "2015");
+                o.get().literal("date", "03");
+                o.get().literal("date", "07");
                 o.get().endRecord();
             });
     }
@@ -466,10 +458,8 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().literal("1", "marc");
-                o.get().literal("2", "json");
-                o.get().endEntity();
+                o.get().literal("title", "marc");
+                o.get().literal("title", "json");
                 o.get().endRecord();
             }
         );
@@ -672,10 +662,8 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("animals");
-                o.get().literal("1", "Cat");
-                o.get().literal("2", "Bobcat");
-                o.get().endEntity();
+                o.get().literal("animals", "Cat");
+                o.get().literal("animals", "Bobcat");
                 o.get().endRecord();
             }
         );
@@ -696,10 +684,8 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("animals");
-                o.get().literal("1", "Lion");
-                o.get().literal("2", "Tiger");
-                o.get().endEntity();
+                o.get().literal("animals", "Lion");
+                o.get().literal("animals", "Tiger");
                 o.get().endRecord();
             }
         );
@@ -806,7 +792,9 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().literal("animals[]", "dog,cat,zebra");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "dog,cat,zebra");
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -1250,10 +1238,8 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().literal("1", "json");
-                o.get().literal("2", "marc");
-                o.get().endEntity();
+                o.get().literal("title", "json");
+                o.get().literal("title", "marc");
                 o.get().endRecord();
             }
         );
@@ -1335,14 +1321,11 @@ public class MetafixMethodTest {
                 i.literal("numbers", "6");
                 i.endRecord();
             },
-            o -> {
+            (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("numbers");
-                o.get().literal("1", "41");
-                o.get().literal("2", "42");
-                o.get().literal("3", "6");
-                o.get().literal("4", "6");
-                o.get().endEntity();
+                o.get().literal("numbers", "41");
+                o.get().literal("numbers", "42");
+                f.apply(2).literal("numbers", "6");
                 o.get().endRecord();
             }
         );
@@ -1361,14 +1344,11 @@ public class MetafixMethodTest {
                 i.literal("numbers", "6");
                 i.endRecord();
             },
-            o -> {
+            (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("numbers");
-                o.get().literal("1", "6");
-                o.get().literal("2", "6");
-                o.get().literal("3", "41");
-                o.get().literal("4", "42");
-                o.get().endEntity();
+                f.apply(2).literal("numbers", "6");
+                o.get().literal("numbers", "41");
+                o.get().literal("numbers", "42");
                 o.get().endRecord();
             }
         );
@@ -1407,14 +1387,11 @@ public class MetafixMethodTest {
                 i.literal("numbers", "6");
                 i.endRecord();
             },
-            o -> {
+            (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("numbers");
-                o.get().literal("1", "6");
-                o.get().literal("2", "6");
-                o.get().literal("3", "42");
-                o.get().literal("4", "41");
-                o.get().endEntity();
+                f.apply(2).literal("numbers", "6");
+                o.get().literal("numbers", "42");
+                o.get().literal("numbers", "41");
                 o.get().endRecord();
             }
         );
@@ -1433,14 +1410,11 @@ public class MetafixMethodTest {
                 i.literal("numbers", "6");
                 i.endRecord();
             },
-            o -> {
+            (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("numbers");
-                o.get().literal("1", "42");
-                o.get().literal("2", "41");
-                o.get().literal("3", "6");
-                o.get().literal("4", "6");
-                o.get().endEntity();
+                o.get().literal("numbers", "42");
+                o.get().literal("numbers", "41");
+                f.apply(2).literal("numbers", "6");
                 o.get().endRecord();
             }
         );
@@ -1461,11 +1435,9 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("numbers");
-                o.get().literal("1", "41");
-                o.get().literal("2", "42");
-                o.get().literal("3", "6");
-                o.get().endEntity();
+                o.get().literal("numbers", "41");
+                o.get().literal("numbers", "42");
+                o.get().literal("numbers", "6");
                 o.get().endRecord();
             }
         );
@@ -1530,11 +1502,9 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("date");
-                o.get().literal("1", "1918");
-                o.get().literal("2", "17");
-                o.get().literal("3", "16");
-                o.get().endEntity();
+                o.get().literal("date", "1918");
+                o.get().literal("date", "17");
+                o.get().literal("date", "16");
                 o.get().endRecord();
             }
         );
@@ -1551,15 +1521,40 @@ public class MetafixMethodTest {
                 i.literal("date", "2021-22-23");
                 i.endRecord();
             },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("date", "1918");
+                o.get().literal("date", "17");
+                o.get().literal("date", "16");
+                o.get().literal("date", "2021");
+                o.get().literal("date", "22");
+                o.get().literal("date", "23");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/106")
+    public void shouldSplitMarkedArrayFieldIntoArrayOfArrays() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "split_field('date[]', '-')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("date[]", "1918-17-16");
+                i.literal("date[]", "2021-22-23");
+                i.endRecord();
+            },
             (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("date");
-                o.get().startEntity("1");
+                o.get().startEntity("date[]");
+                o.get().startEntity("1[]");
                 o.get().literal("1", "1918");
                 o.get().literal("2", "17");
                 o.get().literal("3", "16");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("2[]");
                 o.get().literal("1", "2021");
                 o.get().literal("2", "22");
                 o.get().literal("3", "23");
@@ -1582,19 +1577,16 @@ public class MetafixMethodTest {
                 i.endEntity();
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("date");
-                o.get().startEntity("a");
-                o.get().literal("1", "1918");
-                o.get().literal("2", "17");
-                o.get().literal("3", "16");
+                o.get().literal("a", "1918");
+                o.get().literal("a", "17");
+                o.get().literal("a", "16");
+                o.get().literal("b", "2021");
+                o.get().literal("b", "22");
+                o.get().literal("b", "23");
                 o.get().endEntity();
-                o.get().startEntity("b");
-                o.get().literal("1", "2021");
-                o.get().literal("2", "22");
-                o.get().literal("3", "23");
-                f.apply(2).endEntity();
                 o.get().endRecord();
             }
         );
@@ -1619,11 +1611,10 @@ public class MetafixMethodTest {
                 o.get().startRecord("1");
                 o.get().startEntity("others[]");
                 o.get().startEntity("1");
-                o.get().startEntity("tools");
-                o.get().literal("1", "hammer");
-                o.get().literal("2", "saw");
-                o.get().literal("3", "bow");
-                f.apply(3).endEntity();
+                o.get().literal("tools", "hammer");
+                o.get().literal("tools", "saw");
+                o.get().literal("tools", "bow");
+                f.apply(2).endEntity();
                 o.get().endRecord();
             }
         );
@@ -1709,11 +1700,9 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("numbers");
-                o.get().literal("1", "41");
-                o.get().literal("2", "42");
-                o.get().literal("3", "6");
-                o.get().endEntity();
+                o.get().literal("numbers", "41");
+                o.get().literal("numbers", "42");
+                o.get().literal("numbers", "6");
                 o.get().endRecord();
             }
         );
@@ -1750,20 +1739,17 @@ public class MetafixMethodTest {
                 o.get().startRecord("1");
                 o.get().startEntity("arrays[]");
                 o.get().startEntity("1");
-                o.get().startEntity("number");
-                o.get().literal("1", "41");
-                o.get().literal("2", "23");
-                f.apply(2).endEntity();
+                o.get().literal("number", "41");
+                o.get().literal("number", "23");
+                o.get().endEntity();
                 o.get().startEntity("2");
-                o.get().startEntity("number");
-                o.get().literal("1", "42");
-                o.get().literal("2", "23");
-                f.apply(2).endEntity();
+                o.get().literal("number", "42");
+                o.get().literal("number", "23");
+                o.get().endEntity();
                 o.get().startEntity("3");
-                o.get().startEntity("number");
-                o.get().literal("1", "6");
-                o.get().literal("2", "23");
-                f.apply(3).endEntity();
+                o.get().literal("number", "6");
+                o.get().literal("number", "23");
+                f.apply(2).endEntity();
                 o.get().endRecord();
             }
         );

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -150,12 +150,11 @@ public class MetafixRecordTest {
                 o.get().startRecord("1");
                 o.get().startEntity("deep");
                 o.get().startEntity("nested");
-                o.get().startEntity("1");
                 o.get().literal("field", "value1");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("nested");
                 o.get().literal("field", "value2");
-                f.apply(3).endEntity();
+                f.apply(2).endEntity();
                 o.get().endRecord();
             });
     }
@@ -218,7 +217,8 @@ public class MetafixRecordTest {
     public void add() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "add_field('my.name','patrick')",
-                "add_field('my.name','nicolas')"),
+                "add_field('my.name','nicolas')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.endRecord();
@@ -231,58 +231,59 @@ public class MetafixRecordTest {
 
                 i.startRecord("3");
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("my");
-                o.get().startEntity("name");
-                o.get().literal("1", "patrick");
-                o.get().literal("2", "nicolas");
-                f.apply(2).endEntity();
+                o.get().literal("name", "patrick");
+                o.get().literal("name", "nicolas");
+                o.get().endEntity();
                 o.get().endRecord();
 
                 o.get().startRecord("2");
                 o.get().startEntity("my");
-                o.get().startEntity("name");
-                o.get().literal("1", "max");
-                o.get().literal("2", "patrick");
-                o.get().literal("3", "nicolas");
-                f.apply(2).endEntity();
+                o.get().literal("name", "max");
+                o.get().literal("name", "patrick");
+                o.get().literal("name", "nicolas");
+                o.get().endEntity();
                 o.get().endRecord();
 
                 o.get().startRecord("3");
                 o.get().startEntity("my");
-                o.get().startEntity("name");
-                o.get().literal("1", "patrick");
-                o.get().literal("2", "nicolas");
-                f.apply(2).endEntity();
+                o.get().literal("name", "patrick");
+                o.get().literal("name", "nicolas");
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
     public void addWithAppendInArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "add_field('names.$append','patrick')"),
+                "add_field('names.$append','patrick')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.literal("names", "max");
                 i.literal("names", "mo");
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("names");
-                o.get().literal("1", "max");
-                o.get().literal("2", "mo");
-                o.get().literal("3", "patrick");
-                f.apply(1).endEntity();
+                o.get().literal("names", "max");
+                o.get().literal("names", "mo");
+                o.get().literal("names", "patrick");
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
     public void addWithAppendInHash() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "add_field('author.names.$append','patrick')"),
+                "add_field('author.names.$append','patrick')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("author");
@@ -290,22 +291,24 @@ public class MetafixRecordTest {
                 i.literal("names", "mo");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("names");
-                o.get().literal("1", "max");
-                o.get().literal("2", "mo");
-                o.get().literal("3", "patrick");
-                f.apply(2).endEntity();
+                o.get().literal("names", "max");
+                o.get().literal("names", "mo");
+                o.get().literal("names", "patrick");
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
     public void addWithAppendInArrayWithSubfieldFromRepeatedField() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "add_field('authors.$append.name','patrick')"),
+                "add_field('authors.$append.name','patrick')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("authors");
@@ -315,20 +318,21 @@ public class MetafixRecordTest {
                 i.literal("name", "mo");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("authors");
-                o.get().startEntity("1");
                 o.get().literal("name", "max");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("authors");
                 o.get().literal("name", "mo");
                 o.get().endEntity();
-                o.get().startEntity("3");
+                o.get().startEntity("authors");
                 o.get().literal("name", "patrick");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -520,12 +524,9 @@ public class MetafixRecordTest {
                 i.literal("cnimal", "zebra");
                 i.endRecord();
             },
-            o -> {
+            (o, f) -> {
                 o.get().startRecord("1");
-                o.get().startEntity("animal");
-                o.get().literal("1", "dog");
-                o.get().literal("2", "dog");
-                o.get().endEntity();
+                f.apply(2).literal("animal", "dog");
                 o.get().endRecord();
                 o.get().startRecord("2");
                 o.get().literal("bnimal", "cat");
@@ -651,11 +652,9 @@ public class MetafixRecordTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("animals");
-                o.get().literal("1", "dog");
-                o.get().literal("2", "cat");
-                o.get().literal("3", "zebra");
-                o.get().endEntity();
+                o.get().literal("animals", "dog");
+                o.get().literal("animals", "cat");
+                o.get().literal("animals", "zebra");
                 o.get().literal("animal", "bunny");
                 o.get().startEntity("animols");
                 o.get().literal("name", "bird");
@@ -829,19 +828,18 @@ public class MetafixRecordTest {
                 i.endEntity();
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("animals");
-                o.get().startEntity("1");
                 o.get().literal("name", "dog");
                 o.get().literal("kind", "nice");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("animals");
                 o.get().literal("name", "cat");
                 o.get().endEntity();
-                o.get().startEntity("3");
+                o.get().startEntity("animals");
                 o.get().literal("name", "fox");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -865,19 +863,18 @@ public class MetafixRecordTest {
                 i.endEntity();
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("animals");
-                o.get().startEntity("1");
                 o.get().literal("name", "dog");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("animals");
                 o.get().literal("name", "cat");
                 o.get().endEntity();
-                o.get().startEntity("3");
+                o.get().startEntity("animals");
                 o.get().literal("name", "fox");
                 o.get().literal("kind", "nice");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -901,19 +898,18 @@ public class MetafixRecordTest {
                 i.endEntity();
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("animals");
-                o.get().startEntity("1");
                 o.get().literal("name", "dog");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("animals");
                 o.get().literal("name", "cat");
                 o.get().literal("kind", "nice");
                 o.get().endEntity();
-                o.get().startEntity("3");
+                o.get().startEntity("animals");
                 o.get().literal("name", "fox");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -1209,7 +1205,8 @@ public class MetafixRecordTest {
     public void copyArrayOfStrings() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "copy_field('your','author')",
-                "remove_field('your')"),
+                "remove_field('your')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("your");
@@ -1217,21 +1214,23 @@ public class MetafixRecordTest {
                 i.literal("name", "maxi-ma");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("name");
-                o.get().literal("1", "maxi-mi");
-                o.get().literal("2", "maxi-ma");
-                f.apply(2).endEntity();
+                o.get().literal("name", "maxi-mi");
+                o.get().literal("name", "maxi-ma");
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
     public void renameArrayOfStrings() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "move_field('your','author')"),
+                "move_field('your','author')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("your");
@@ -1239,15 +1238,16 @@ public class MetafixRecordTest {
                 i.literal("name", "maxi-ma");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("name");
-                o.get().literal("1", "maxi-mi");
-                o.get().literal("2", "maxi-ma");
-                f.apply(2).endEntity();
+                o.get().literal("name", "maxi-mi");
+                o.get().literal("name", "maxi-ma");
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -1495,8 +1495,6 @@ public class MetafixRecordTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().endEntity();
                 o.get().endRecord();
             });
     }
@@ -1631,12 +1629,10 @@ public class MetafixRecordTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("foo");
-                o.get().literal("1", "a");
-                o.get().literal("2", "b");
-                o.get().literal("3", "c");
-                o.get().literal("4", "d");
-                o.get().endEntity();
+                o.get().literal("foo", "a");
+                o.get().literal("foo", "b");
+                o.get().literal("foo", "c");
+                o.get().literal("foo", "d");
                 o.get().endRecord();
             });
     }
@@ -1941,12 +1937,12 @@ public class MetafixRecordTest {
                 i.endEntity();
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("arrays[]");
-                o.get().startEntity("1"); // TODO: Preserve array!? (`1[]`)
+                // TODO: Preserve nested array!? (`1[]`)
                 o.get().literal("1", ":-P yuck");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );
@@ -1973,39 +1969,41 @@ public class MetafixRecordTest {
     @Test
     public void repeatToArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "nothing()"),
+                "nothing()"
+            ),
             i -> {
                 i.startRecord("1");
                 i.literal("name", "max");
                 i.literal("name", "mo");
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "max");
-                o.get().literal("2", "mo");
-                o.get().endEntity();
+                o.get().literal("name", "max");
+                o.get().literal("name", "mo");
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
     public void accessArrayByIndex() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "upcase('name.2')"),
+                "upcase('name.2')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.literal("name", "max");
                 i.literal("name", "mo");
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "max");
-                o.get().literal("2", "MO");
-                o.get().endEntity();
+                o.get().literal("name", "max");
+                o.get().literal("name", "MO");
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -2039,10 +2037,8 @@ public class MetafixRecordTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("name");
-                o.get().literal("1", "MAX");
-                o.get().literal("2", "MO");
-                o.get().endEntity();
+                o.get().literal("name", "MAX");
+                o.get().literal("name", "MO");
                 o.get().endRecord();
             }
         );
@@ -2051,7 +2047,8 @@ public class MetafixRecordTest {
     @Test
     public void repeatToArrayOfObjects() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "nothing()"),
+                "nothing()"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("author");
@@ -2061,23 +2058,25 @@ public class MetafixRecordTest {
                 i.literal("name", "mo");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("1");
                 o.get().literal("name", "max");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("author");
                 o.get().literal("name", "mo");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
     public void accessArrayOfObjectsByIndex() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "upcase('author.2.name')"),
+                "upcase('author.2.name')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("author");
@@ -2087,24 +2086,26 @@ public class MetafixRecordTest {
                 i.literal("name", "mo");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("1");
                 o.get().literal("name", "max");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("author");
                 o.get().literal("name", "MO");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
     // TODO: implement implicit iteration?
     public void accessArrayOfObjectsByWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "upcase('author.*.name')"),
+                "upcase('author.*.name')"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("author");
@@ -2114,17 +2115,18 @@ public class MetafixRecordTest {
                 i.literal("name", "mo");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("1");
                 o.get().literal("name", "MAX");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("author");
                 o.get().literal("name", "MO");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -2132,7 +2134,8 @@ public class MetafixRecordTest {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do list('path':'author','var':'a')",
                 "  upcase('a.name')",
-                "end"),
+                "end"
+            ),
             i -> {
                 i.startRecord("1");
                 i.startEntity("author");
@@ -2142,17 +2145,18 @@ public class MetafixRecordTest {
                 i.literal("name", "mo");
                 i.endEntity();
                 i.endRecord();
-            }, (o, f) -> {
+            },
+            o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("author");
-                o.get().startEntity("1");
                 o.get().literal("name", "MAX");
                 o.get().endEntity();
-                o.get().startEntity("2");
+                o.get().startEntity("author");
                 o.get().literal("name", "MO");
-                f.apply(2).endEntity();
+                o.get().endEntity();
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
     @Test
@@ -2168,10 +2172,8 @@ public class MetafixRecordTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("title");
-                o.get().literal("1", "marc");
-                o.get().literal("2", "json");
-                o.get().endEntity();
+                o.get().literal("title", "marc");
+                o.get().literal("title", "json");
                 o.get().literal(ArgumentMatchers.eq("test"), ArgumentMatchers.argThat(i -> Integer.parseInt(i) < 100));
                 o.get().endRecord();
             }
@@ -2256,11 +2258,9 @@ public class MetafixRecordTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().startEntity("animals");
-                o.get().literal("1", "cat");
-                o.get().literal("2", "dog");
-                o.get().literal(ArgumentMatchers.eq("3"), ArgumentMatchers.argThat(i -> Integer.parseInt(i) < 100));
-                o.get().endEntity();
+                o.get().literal("animals", "cat");
+                o.get().literal("animals", "dog");
+                o.get().literal(ArgumentMatchers.eq("animals"), ArgumentMatchers.argThat(i -> Integer.parseInt(i) < 100));
                 o.get().endRecord();
             }
         );
@@ -2268,7 +2268,7 @@ public class MetafixRecordTest {
 
     @Test
     @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
-    public void shouldAddRandomNumberToUnmarkedArrayObject() {
+    public void shouldNotAppendRandomNumberToHash() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "random('animals.$append', '100')"
             ),
@@ -2285,7 +2285,6 @@ public class MetafixRecordTest {
                 o.get().startEntity("animals");
                 o.get().literal("1", "cat");
                 o.get().literal("2", "dog");
-                o.get().literal(ArgumentMatchers.eq("3"), ArgumentMatchers.argThat(i -> Integer.parseInt(i) < 100));
                 o.get().endEntity();
                 o.get().endRecord();
             }
@@ -2403,10 +2402,9 @@ public class MetafixRecordTest {
             (o, f) -> {
                 o.get().startRecord("1");
                 o.get().startEntity("XYmals");
-                o.get().startEntity("XYmal");
-                o.get().literal("1", "dog");
-                o.get().literal("2", "cat");
-                f.apply(2).endEntity();
+                o.get().literal("XYmal", "dog");
+                o.get().literal("XYmal", "cat");
+                o.get().endEntity();
                 o.get().startEntity("others");
                 o.get().literal("XYmal", "human");
                 o.get().literal("cXYster", "metall");

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
@@ -162,20 +162,16 @@ public class MetafixScriptTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().literal("record", "1");
-                o.get().startEntity("trace");
-                o.get().literal("1", "before include");
-                o.get().literal("2", "base 1");
-                o.get().literal("3", "after include");
-                o.get().endEntity();
+                o.get().literal("trace", "before include");
+                o.get().literal("trace", "base 1");
+                o.get().literal("trace", "after include");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
                 o.get().literal("record", "2");
-                o.get().startEntity("trace");
-                o.get().literal("1", "before include");
-                o.get().literal("2", "base 2");
-                o.get().literal("3", "after include");
-                o.get().endEntity();
+                o.get().literal("trace", "before include");
+                o.get().literal("trace", "base 2");
+                o.get().literal("trace", "after include");
                 o.get().endRecord();
             }
         );
@@ -208,32 +204,26 @@ public class MetafixScriptTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().literal("record", "1");
-                o.get().startEntity("data");
-                o.get().literal("1", "marc");
-                o.get().literal("2", "json");
-                o.get().endEntity();
-                o.get().startEntity("trace");
-                o.get().literal("1", "before bind");
-                o.get().literal("2", "before include marc");
-                o.get().literal("3", "marc 1");
-                o.get().literal("4", "after include MARC");
-                o.get().literal("5", "before include json");
-                o.get().literal("6", "json 1");
-                o.get().literal("7", "after include JSON");
-                o.get().literal("8", "after bind");
-                o.get().endEntity();
+                o.get().literal("data", "marc");
+                o.get().literal("data", "json");
+                o.get().literal("trace", "before bind");
+                o.get().literal("trace", "before include marc");
+                o.get().literal("trace", "marc 1");
+                o.get().literal("trace", "after include MARC");
+                o.get().literal("trace", "before include json");
+                o.get().literal("trace", "json 1");
+                o.get().literal("trace", "after include JSON");
+                o.get().literal("trace", "after bind");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
                 o.get().literal("record", "2");
                 o.get().literal("data", "test");
-                o.get().startEntity("trace");
-                o.get().literal("1", "before bind");
-                o.get().literal("2", "before include test");
-                o.get().literal("3", "test 2");
-                o.get().literal("4", "after include TEST");
-                o.get().literal("5", "after bind");
-                o.get().endEntity();
+                o.get().literal("trace", "before bind");
+                o.get().literal("trace", "before include test");
+                o.get().literal("trace", "test 2");
+                o.get().literal("trace", "after include TEST");
+                o.get().literal("trace", "after bind");
                 o.get().endRecord();
             }
         );
@@ -272,20 +262,16 @@ public class MetafixScriptTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().literal("record", "1");
-                o.get().startEntity("trace");
-                o.get().literal("1", "before include");
-                o.get().literal("2", "base 1");
-                o.get().literal("3", "after include");
-                o.get().endEntity();
+                o.get().literal("trace", "before include");
+                o.get().literal("trace", "base 1");
+                o.get().literal("trace", "after include");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
                 o.get().literal("record", "2");
-                o.get().startEntity("trace");
-                o.get().literal("1", "before include");
-                o.get().literal("2", "base 2");
-                o.get().literal("3", "after include");
-                o.get().endEntity();
+                o.get().literal("trace", "before include");
+                o.get().literal("trace", "base 2");
+                o.get().literal("trace", "after include");
                 o.get().endRecord();
             }
         );
@@ -308,24 +294,20 @@ public class MetafixScriptTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().literal("record", "1");
-                o.get().startEntity("trace");
-                o.get().literal("1", "before nested");
-                o.get().literal("2", "before include");
-                o.get().literal("3", "base 1");
-                o.get().literal("4", "after include");
-                o.get().literal("5", "after nested");
-                o.get().endEntity();
+                o.get().literal("trace", "before nested");
+                o.get().literal("trace", "before include");
+                o.get().literal("trace", "base 1");
+                o.get().literal("trace", "after include");
+                o.get().literal("trace", "after nested");
                 o.get().endRecord();
 
                 o.get().startRecord("2");
                 o.get().literal("record", "2");
-                o.get().startEntity("trace");
-                o.get().literal("1", "before nested");
-                o.get().literal("2", "before include");
-                o.get().literal("3", "base 2");
-                o.get().literal("4", "after include");
-                o.get().literal("5", "after nested");
-                o.get().endEntity();
+                o.get().literal("trace", "before nested");
+                o.get().literal("trace", "before include");
+                o.get().literal("trace", "base 2");
+                o.get().literal("trace", "after include");
+                o.get().literal("trace", "after nested");
                 o.get().endRecord();
             }
         );


### PR DESCRIPTION
Resolves #106.

Notable behaviour changes w.r.t. unmarked arrays:

- Array to string: [`format`](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-bb6266bd9a7da63237fec55eb21906fe98b74a978fe6816b01421209660b51b7L249-R245), [`join_field`](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-bb6266bd9a7da63237fec55eb21906fe98b74a978fe6816b01421209660b51b7L809-R797)
- String to array: [`parse_text`](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-bb6266bd9a7da63237fec55eb21906fe98b74a978fe6816b01421209660b51b7L266-R262), `split_field` ([1](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-bb6266bd9a7da63237fec55eb21906fe98b74a978fe6816b01421209660b51b7L1533-R1507), [2](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-bb6266bd9a7da63237fec55eb21906fe98b74a978fe6816b01421209660b51b7R1526-R1531), [3](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-bb6266bd9a7da63237fec55eb21906fe98b74a978fe6816b01421209660b51b7L1588-L1597), [4](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-bb6266bd9a7da63237fec55eb21906fe98b74a978fe6816b01421209660b51b7L1622-R1617))
- Empty array: [`remove_field`](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-25b98d43ad1210c8ef1168013b98f9724d1d5b4205a911ba146f4bdfebb32a9bL1498-L1499), [`vacuum`](https://github.com/metafacture/metafacture-fix/pull/131/files#diff-25b98d43ad1210c8ef1168013b98f9724d1d5b4205a911ba146f4bdfebb32a9bL1947-R1945)