### PR TITLE
Fix path wildcards in combination with arrays.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -533,8 +533,10 @@ public class Value {
          */
         public Value get(final String field) {
             // TODO: special treatment (only) for exact matches?
-            final List<Value> list = matchFields(field, Stream::filter).map(this::getField).collect(Collectors.toList());
-            return list.isEmpty() ? null : list.size() == 1 ? list.get(0) : new Value(list);
+            final List<Value> list = findFields(field).map(this::getField).collect(Collectors.toList());
+            return list.isEmpty() ? null : list.size() == 1 ? list.get(0) : newArray(a -> list.forEach(v -> v.matchType()
+                        .ifArray(b -> b.forEach(a::add))
+                        .orElse(a::add)));
         }
 
         public Value getField(final String field) {
@@ -614,7 +616,7 @@ public class Value {
          * @param fields the field names
          */
         public void retainFields(final Collection<String> fields) {
-            map.keySet().retainAll(fields.stream().flatMap(f -> matchFields(f, Stream::filter)).collect(Collectors.toSet()));
+            map.keySet().retainAll(fields.stream().flatMap(this::findFields).collect(Collectors.toSet()));
         }
 
         /**
@@ -658,7 +660,11 @@ public class Value {
         }
 
         /*package-private*/ void modifyFields(final String pattern, final Consumer<String> consumer) {
-            matchFields(pattern, Stream::filter).collect(Collectors.toSet()).forEach(consumer);
+            findFields(pattern).collect(Collectors.toSet()).forEach(consumer);
+        }
+
+        private Stream<String> findFields(final String pattern) {
+            return matchFields(pattern, Stream::filter);
         }
 
         private <T> T matchFields(final String pattern, final BiFunction<Stream<String>, Predicate<String>, T> function) {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -598,25 +598,25 @@ public class MetafixBindTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/119")
+    // See https://github.com/metafacture/metafacture-fix/issues/119
     public void shouldIterateOverListWithCharacterClass() {
         shouldIterateOverList("n[ao]me", 3);
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/119")
+    // See https://github.com/metafacture/metafacture-fix/issues/119
     public void shouldIterateOverListWithAlternation() {
         shouldIterateOverList("name|nome", 3);
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/119")
+    // See https://github.com/metafacture/metafacture-fix/issues/119
     public void shouldIterateOverListWithWildcard() {
         shouldIterateOverList("n?me", 3);
     }
 
     @Test // checkstyle-disable-line JavaNCSS
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/119")
+    // See https://github.com/metafacture/metafacture-fix/issues/119
     public void shouldPerformComplexOperationWithPathWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('coll[]')",

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -19,7 +19,6 @@ package org.metafacture.metafix;
 import org.metafacture.framework.StreamReceiver;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -569,19 +568,19 @@ public class MetafixIfTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/115")
+    // See https://github.com/metafacture/metafacture-fix/issues/115
     public void shouldEqualAnyCharacterClass() {
         shouldEqualAny("n[ao]me");
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/115")
+    // See https://github.com/metafacture/metafacture-fix/issues/115
     public void shouldEqualAnyAlternation() {
         shouldEqualAny("name|nome");
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/115")
+    // See https://github.com/metafacture/metafacture-fix/issues/115
     public void shouldEqualAnyWildcard() {
         shouldEqualAny("n?me");
     }
@@ -620,7 +619,7 @@ public class MetafixIfTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/115")
+    // See https://github.com/metafacture/metafacture-fix/issues/115
     public void shouldEqualAnyNestedCharacterClass() {
         shouldEqualAnyNested("data.n[ao]me");
     }
@@ -631,7 +630,7 @@ public class MetafixIfTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/115")
+    // See https://github.com/metafacture/metafacture-fix/issues/115
     public void shouldEqualAnyNestedWildcard() {
         shouldEqualAnyNested("data.n?me");
     }
@@ -672,7 +671,7 @@ public class MetafixIfTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/115")
+    // See https://github.com/metafacture/metafacture-fix/issues/115
     public void shouldEqualAnyListBindCharacterClass() {
         shouldEqualAnyListBind("$i.n[ao]me");
     }
@@ -683,7 +682,7 @@ public class MetafixIfTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/115")
+    // See https://github.com/metafacture/metafacture-fix/issues/115
     public void shouldEqualAnyListBindWildcard() {
         shouldEqualAnyListBind("$i.n?me");
     }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -662,7 +662,12 @@ public class MetafixRecordTest {
                 o.get().endEntity();
                 o.get().literal("ANIMALS", "dragon and unicorn");
                 o.get().startEntity("stringimals[]");
-                o.get().literal("1", "bunny");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "cat");
+                o.get().literal("3", "zebra");
+                o.get().literal("4", "bunny");
+                // TODO: Why is the hash (`animols`) not expected here?
+                // See also https://github.com/metafacture/metafacture-fix/issues/89#issuecomment-999433570
                 o.get().endEntity();
                 o.get().endRecord();
             }


### PR DESCRIPTION
Resolves #115 and #119.

NOTE: The updated test `MetafixRecordTest.appendWithAsteriksWildcardAtTheEnd()` was probably wrong in the first place; the original [comment](https://github.com/metafacture/metafacture-fix/issues/89#issuecomment-999433570) expected the other values as well, but the actual [review](https://github.com/TobiasNx/fix-FunctionalReview-Testing/blob/master/data/approved/wildCardTest/expected_test6.json#L13) (which was the basis for the unit test) did not.