### PR TITLE
Apply relative path "magic" to file maps.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -21,7 +21,6 @@ import org.metafacture.metafix.fix.Fix;
 import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.maps.FileMap;
 
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -44,26 +43,13 @@ public enum FixMethod implements FixFunction {
         @Override
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final String includeFile = params.get(0);
-            final String includePath;
 
             if (!Metafix.isFixFile(includeFile)) {
                 throw new IllegalArgumentException("Not a Fix file: " + includeFile);
             }
 
             // TODO: Catmandu load path
-            if (includeFile.startsWith(".")) {
-                final String fixFile = metafix.getFixFile();
-
-                if (fixFile != null) {
-                    includePath = Paths.get(fixFile).resolveSibling(includeFile).toString();
-                }
-                else {
-                    throw new IllegalArgumentException("Cannot resolve relative path: " + includeFile);
-                }
-            }
-            else {
-                includePath = includeFile;
-            }
+            final String includePath = metafix.resolvePath(includeFile);
 
             final RecordTransformer recordTransformer = metafix.getRecordTransformer();
             recordTransformer.setRecord(recordTransformer.transformRecord(
@@ -83,9 +69,9 @@ public enum FixMethod implements FixFunction {
             final FileMap fileMap = new FileMap();
 
             fileMap.setSeparator(options.getOrDefault(FILEMAP_SEPARATOR_OPTION, FILEMAP_DEFAULT_SEPARATOR));
-            fileMap.setFile(fileName);
+            fileMap.setFile(metafix.resolvePath(fileName));
 
-            metafix.putMap(params.size() <= 1 ? fileName : params.get(1), fileMap);
+            metafix.putMap(params.size() > 1 ? params.get(1) : fileName, fileMap);
         }
     },
     put_map {

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -126,8 +127,18 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
         return fixDef.endsWith(FIX_EXTENSION);
     }
 
-    /*package-private*/ String getFixFile() {
-        return fixFile;
+    public String resolvePath(final String path) {
+        if (path.startsWith(".")) {
+            if (fixFile != null) {
+                return Paths.get(fixFile).resolveSibling(path).toString();
+            }
+            else {
+                throw new IllegalArgumentException("Cannot resolve relative path: " + path);
+            }
+        }
+        else {
+            return path;
+        }
     }
 
     public RecordTransformer getRecordTransformer() {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -156,6 +156,31 @@ public class MetafixLookupTest {
     }
 
     @Test
+    public void shouldNotLookupInRelativeExternalFileMapFromInlineScript() {
+        final String mapFile = "../maps/test.csv";
+
+        MetafixTestHelpers.assertThrowsCause(IllegalArgumentException.class, "Cannot resolve relative path: " + mapFile, () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    LOOKUP + " '" + mapFile + "')"
+                ),
+                i -> {
+                    i.startRecord("");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldLookupInRelativeExternalFileMapFromExternalScript() {
+        assertMap(
+                "src/test/resources/org/metafacture/metafix/fixes/filemap_lookup.fix"
+        );
+    }
+
+    @Test
     public void shouldLookupInSeparateExternalFileMapWithName() {
         assertMap(
                 "put_filemap('" + CSV_MAP + "', 'testMap')",

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
@@ -115,6 +115,29 @@ public class MetafixScriptTest {
     }
 
     @Test
+    public void shouldNotPutRelativeExternalFileMapFromInlineScript() {
+        final String mapFile = "../maps/test.csv";
+
+        MetafixTestHelpers.assertThrowsCause(IllegalArgumentException.class, "Cannot resolve relative path: " + mapFile, () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "put_filemap('" + mapFile + "')"
+                ),
+                i -> {
+                    i.startRecord("");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldPutRelativeExternalFileMapFromExternalScript() {
+        assertMap("src/test/resources/org/metafacture/metafix/fixes/filemap.fix", MAP_NAME);
+    }
+
+    @Test
     public void shouldPutMultipleExternalFileMaps() {
         assertFix("put_filemap('" + CSV_MAP + "')\nput_filemap('" + TSV_MAP + "')", f -> {
             assertMap(f, CSV_MAP);

--- a/metafix/src/test/resources/org/metafacture/metafix/fixes/filemap.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/fixes/filemap.fix
@@ -1,0 +1,1 @@
+put_filemap("../maps/test.csv", "testMap")

--- a/metafix/src/test/resources/org/metafacture/metafix/fixes/filemap_lookup.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/fixes/filemap_lookup.fix
@@ -1,0 +1,1 @@
+lookup("title.*", "../maps/test.csv")


### PR DESCRIPTION
Allows file maps to be referenced relative to Fix file (see #12 for the introduction of this mechanism in the context of the `include()` function).