### PR TITLE
Introduce `@MetafixToDo` annotation to mark tests as disabled.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ subprojects {
       'equalsverifier': '3.8.2',
       'jetty':          '9.4.14.v20181114',
       'jquery':         '3.3.1-1',
-      'junit_jupiter':  '5.4.2',
+      'junit_jupiter':  '5.8.2',
       'junit_platform': '1.4.2',
       'metafacture':    '5.3.1',
       'mockito':        '2.27.0',

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -18,7 +18,6 @@ package org.metafacture.metafix;
 
 import org.metafacture.framework.StreamReceiver;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -32,6 +31,7 @@ import java.util.Arrays;
  * @author Fabian Steeg
  */
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(MetafixToDo.Extension.class)
 public class MetafixBindTest {
 
     @Mock
@@ -442,7 +442,7 @@ public class MetafixBindTest {
     }
 
     @Test
-    @Disabled("implement Fix-style binds with collectors?")
+    @MetafixToDo("implement Fix-style binds with collectors?")
     public void ifInCollector() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do entity('author')",
@@ -466,7 +466,7 @@ public class MetafixBindTest {
     }
 
     @Test
-    @Disabled("implement Fix-style binds with collectors?")
+    @MetafixToDo("implement Fix-style binds with collectors?")
     public void ifInCollectorMultiRecords() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do entity('author')",
@@ -510,7 +510,7 @@ public class MetafixBindTest {
     }
 
     @Test
-    @Disabled("implement Fix-style binds with collectors?")
+    @MetafixToDo("implement Fix-style binds with collectors?")
     public void ifInCollectorChoose() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do choose(flushWith: 'record')",
@@ -537,7 +537,7 @@ public class MetafixBindTest {
     }
 
     @Test
-    @Disabled("implement Fix-style binds with collectors?")
+    @MetafixToDo("implement Fix-style binds with collectors?")
     public void ifInCollectorCombine() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do combine(name: 'fullName', value: '${first} ${last}')",
@@ -656,7 +656,7 @@ public class MetafixBindTest {
 
     @Test
     // See https://github.com/metafacture/metafacture-fix/issues/119
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/143")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/143")
     public void shouldIterateOverListOfHashesWithAlternation() {
         shouldIterateOverListOfHashes("name.value|nome.value", 3);
     }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -19,7 +19,6 @@ package org.metafacture.metafix;
 import org.metafacture.framework.StreamReceiver;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -34,6 +33,7 @@ import java.util.Arrays;
  * @author Fabian Steeg
  */
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(MetafixToDo.Extension.class)
 public class MetafixMethodTest {
 
     @Mock
@@ -1306,7 +1306,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/135")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/135")
     public void shouldReplaceAllRegexesInArrayByArrayWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "replace_all('names.$last', 'a', 'X')"
@@ -1358,7 +1358,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/135")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/135")
     public void shouldReplaceAllRegexesInArraySubFieldByArrayWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "replace_all('names[].$last.name', 'a', 'X')"
@@ -1428,7 +1428,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldReverseArrayOfStringsWithAsterisk() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "reverse('test[].*')"
@@ -1455,7 +1455,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldReverseArrayOfHashesWithAsterisk() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "reverse('ANIMALS[].*')"
@@ -1626,7 +1626,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldSortArrayFieldWithAsterisk() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "sort_field('OTHERS[].*.dnimals[]')"
@@ -1717,7 +1717,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("Arrays in arrays need to be preserved. See disabled isArray in FixPath#appendIn.")
+    @MetafixToDo("Arrays in arrays need to be preserved. See disabled isArray in FixPath#appendIn.")
     public void moveToNestedArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "move_field('date[]', 'd[]')"
@@ -1757,7 +1757,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("Arrays in arrays need to be preserved. See disabled isArray in FixPath#appendIn.")
+    @MetafixToDo("Arrays in arrays need to be preserved. See disabled isArray in FixPath#appendIn.")
     public void shouldSplitMarkedArrayFieldIntoArrayOfArrays() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "split_field('date[]', '-')"
@@ -1815,7 +1815,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100 and https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/100 and https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldSplitNestedField() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "split_field('others[].*.tools', '--')"
@@ -1864,7 +1864,7 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @Disabled("java.lang.IllegalStateException: Expected String, got Array; see https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("java.lang.IllegalStateException: Expected String, got Array; see https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldSumArrayFieldWithAsterisk() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "sum('OTHERS[].*.dumbers[]')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -18,7 +18,6 @@ package org.metafacture.metafix;
 
 import org.metafacture.framework.StreamReceiver;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -34,6 +33,7 @@ import java.util.Arrays;
  * @author Fabian Steeg
  */
 @ExtendWith(MockitoExtension.class) // checkstyle-disable-line JavaNCSS
+@ExtendWith(MetafixToDo.Extension.class)
 public class MetafixRecordTest {
 
     @Mock
@@ -426,7 +426,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/92")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/92")
     public void complexAppendWithArrayOfObjects() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "copy_field('others', 'animals[].$append')",
@@ -741,7 +741,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldCopyNestedArrayFieldWithAsterisk() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('TEST_4[]')",
@@ -1098,7 +1098,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldAddArraySubFieldWithAsterisk() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "add_field('coll[].*.c', 'test')"
@@ -2409,7 +2409,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("See https://github.com/metafacture/metafacture-fix/issues/100")
+    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/100")
     public void shouldNotAppendRandomNumberToHash() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "random('animals.$append', '100')"
@@ -2518,7 +2518,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
+    @MetafixToDo("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/100")
     public void shouldRenameAllFieldsInHash() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "rename('.', ani, XY)"
@@ -2562,7 +2562,7 @@ public class MetafixRecordTest {
     }
 
     @Test
-    @Disabled("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/121")
+    @MetafixToDo("java.lang.ArrayIndexOutOfBoundsException: 0; see https://github.com/metafacture/metafacture-fix/issues/121")
     public void shouldRenameArrayFieldWithAsterisk() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "rename('OTHERS[].*', 'd', 'XY')"

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixSelectorTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixSelectorTest.java
@@ -18,7 +18,6 @@ package org.metafacture.metafix;
 
 import org.metafacture.framework.StreamReceiver;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -33,7 +32,7 @@ import java.util.Arrays;
  *
  */
 @ExtendWith(MockitoExtension.class)
-@Disabled("TODO: support Fix-style selectors https://github.com/LibreCat/Catmandu/wiki/Selectors")
+@ExtendWith(MetafixToDo.Extension.class)
 public final class MetafixSelectorTest {
 
     @Mock
@@ -42,6 +41,7 @@ public final class MetafixSelectorTest {
     public MetafixSelectorTest() { }
 
     @Test
+    @MetafixToDo("Support reject() with condition")
     public void reject() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "reject exists(error)"),
@@ -64,19 +64,23 @@ public final class MetafixSelectorTest {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "if exists(error)",
                 "  reject()",
-                "end"),
+                "end"
+            ),
             i -> {
                 i.startRecord("1");
                 i.literal("error", "details");
                 i.endRecord();
 
                 i.startRecord("2");
+                i.literal("name", "Mary");
                 i.endRecord();
-            }, o -> {
+            },
+            o -> {
                 o.get().startRecord("2");
                 o.get().literal("name", "Mary");
                 o.get().endRecord();
-            });
+            }
+        );
     }
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixToDo.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixToDo.java
@@ -1,0 +1,81 @@
+package org.metafacture.metafix;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.opentest4j.TestAbortedException;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MetafixToDo.Handler.class)
+public @interface MetafixToDo {
+
+    String value();
+
+    class Extension implements InvocationInterceptor {
+
+        private Extension() {
+        }
+
+        @Override
+        public void interceptTestMethod(final InvocationInterceptor.Invocation<Void> invocation, final ReflectiveInvocationContext<Method> invocationContext, final ExtensionContext extensionContext) throws Throwable {
+            try {
+                invocation.proceed();
+            }
+            catch (final Throwable e) { // checkstyle-disable-line IllegalCatch
+                handleAnnotation(invocationContext, a -> {
+                    throw new TestAbortedException(a.value(), e);
+                });
+
+                throw e;
+            }
+
+            handleAnnotation(invocationContext, a -> Assertions.fail("Marked as " + a + ", but passed."));
+        }
+
+        private void handleAnnotation(final ReflectiveInvocationContext<Method> invocationContext, final Consumer<MetafixToDo> consumer) {
+            final MetafixToDo annotation = invocationContext.getExecutable().getAnnotation(MetafixToDo.class);
+
+            if (annotation != null) {
+                consumer.accept(annotation);
+            }
+        }
+
+    }
+
+    class Handler implements ExecutionCondition {
+
+        private static final Class<Extension> EXTENSION_CLASS = Extension.class;
+        private static final String EXTENSION_NAME = EXTENSION_CLASS.getTypeName();
+
+        private Handler() {
+        }
+
+        @Override
+        public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+            for (final ExtendWith annotation : context.getTestClass().get().getAnnotationsByType(ExtendWith.class)) {
+                for (final Class<? extends org.junit.jupiter.api.extension.Extension> extensionClass : annotation.value()) {
+                    if (extensionClass.isAssignableFrom(EXTENSION_CLASS)) {
+                        return ConditionEvaluationResult.enabled("Extension present: " + EXTENSION_NAME);
+                    }
+                }
+            }
+
+            Assertions.fail("Extension missing: " + EXTENSION_NAME);
+            return null; // not reached
+        }
+
+    }
+
+}


### PR DESCRIPTION
Since we're keeping quite a few disabled tests in stock that indicate pending work (which is a good thing), it's not always clear (to me, at least) when any of those tests might be resolved due to (seemingly unrelated) fixes. So I'd like to propose a new `@MetafixToDo` annotation instead of the current `@Disabled` annotation, which takes care of reminding us of no longer failing tests: Failing tests marked as "to do" will be reported as *skipped* (just as before¹); passing tests marked as "to do" will be reported as *failed* (so we know we can remove the annotation).

¹ Except not quite: One problem with the proposed approach is that the log messages of still failing tests somewhat clutter the test output. We could reduce the log level for tests to `ERROR` as a remedy. OTOH, it's not entirely useless to see those messages, because sometimes disabled tests fail for the wrong reason ;) (see `MetafixSelectorTest.reject()` for instance).