### PR TITLE
Ignore unknown internal maps in `lookup()` Fix function.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -21,6 +21,7 @@ import org.metafacture.metafix.fix.Fix;
 import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.maps.FileMap;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -377,7 +378,12 @@ public enum FixMethod implements FixFunction {
                 final String mapName = params.get(1);
 
                 if (!metafix.getMapNames().contains(mapName)) {
-                    put_filemap.apply(metafix, record, Arrays.asList(mapName), options);
+                    if (mapName.contains(".") || mapName.contains(File.separator)) {
+                        put_filemap.apply(metafix, record, Arrays.asList(mapName), options);
+                    }
+                    else {
+                        // Probably an unknown internal map? Log a warning?
+                    }
                 }
 
                 map = metafix.getMap(mapName);

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -279,10 +279,29 @@ public class MetafixLookupTest {
     }
 
     @Test
-    public void shouldFailLookupInUnknownNamedMap() {
-        MetafixTestHelpers.assertThrowsCause(MorphExecutionException.class, "File not found: testMap", () ->
+    public void shouldNotLookupInUnknownInternalMap() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                LOOKUP + " 'testMap')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("title", "Aloha");
+                i.literal("title", "Moin");
+                i.literal("title", "Hey");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldFailLookupInUnknownExternalMap() {
+        MetafixTestHelpers.assertThrowsCause(MorphExecutionException.class, "File not found: testMap.csv", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                    LOOKUP + " 'testMap')"
+                    LOOKUP + " 'testMap.csv')"
                 ),
                 i -> {
                     i.startRecord("1");


### PR DESCRIPTION
Metamorph does this with any map (including external file maps) in `<lookup>`, while Catmandu doesn't have a concept of _named_ internal maps.

So the middle ground here is to apply a heuristic for determining whether an internal or an external file map was probably referenced.