### PR TITLE
Include `editorconfig-checker` to complement `editorconfig-gradle-plugin`.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{fix,gradle,json,sh,yml}]
+[*.{fix,gradle,json,md,mwe2,sh,vim,xtext,yml}]
 indent_size = 2
+
+[*.tmLanguage]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .gradle/
+bin/
+!/misc/bin/
 build/
 generated/
 xtext-gen/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .gradle/
-bin/
 build/
 generated/
 xtext-gen/

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,7 @@
 .gradle/
-bin/
-!/misc/bin/
 build/
 generated/
 xtext-gen/
-.project
-.classpath
 out/
 node_modules/
 xtext-server/

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@ editorconfig {
   ]
 }
 
+task editorconfigChecker(type: Exec, group: 'Verification') {
+  executable 'misc/bin/editorconfig-checker'
+  args('-exclude', '/bin/|/\\.|^gradlew.*|^LICENSE$')
+}
+
+editorconfigCheck.dependsOn(editorconfigChecker)
 check.dependsOn(editorconfigCheck)
 
 subprojects {

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfStrings/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfStrings/input.json
@@ -1,4 +1,4 @@
 {
-	"animals": ["dog", "cat", "zebra"],
-	"animals_2": ["dog", "cat", "zebra"]
+  "animals": ["dog", "cat", "zebra"],
+  "animals_2": ["dog", "cat", "zebra"]
 }

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/set_arrayIntoArray/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/set_arrayIntoArray/expected.json
@@ -17,6 +17,5 @@
     "test_2" : [ "test", "test" ]
   },{
     "test_3" : [ "test", "test", "test" ]
-  }
- ]
+  } ]
 }


### PR DESCRIPTION
`editorconfig-gradle-plugin` doesn't have sufficient [support for `.editorconfig` properties](https://github.com/ec4j/editorconfig-gradle-plugin#how-it-works).

`editorconfig-checker` has been added in version [2.4.0](https://github.com/editorconfig-checker/editorconfig-checker/releases/tag/2.4.0) for linux amd64.