### PR TITLE
Add additional append prepend test

### DIFF
--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/expected.json
@@ -1,0 +1,15 @@
+{
+  "animals" : [ {
+    "name" : "Jake",
+    "type" : "dog is cool"
+  }, {
+    "name" : "Blacky",
+    "type" : "bird is cool"
+  } ]
+}
+{
+  "animals" : [ {
+    "name" : "Test",
+    "type" : "test is cool"
+  } ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/input.json
@@ -1,0 +1,15 @@
+{
+  "animals": [ {
+      "name": "Jake",
+      "type": "dog"
+  }, {
+    "name": "Blacky",
+    "type": "bird"
+  } ]
+}
+{
+  "animals": [ {
+    "name": "Test",
+    "type": "test"
+  } ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/test.fix
@@ -1,0 +1,1 @@
+append("animals[].*.type", " is cool")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithAsteriskArrayWildcard/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/expected.json
@@ -1,0 +1,15 @@
+{
+  "animals" : [ {
+    "name" : "Jake",
+    "type" : "Big dog"
+  }, {
+    "name" : "Blacky",
+    "type" : "Big bird"
+  } ]
+}
+{
+  "animals" : [ {
+    "name" : "Test",
+    "type" : "Big test"
+  } ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/input.json
@@ -1,0 +1,20 @@
+{
+  "animals": [
+    {
+      "name": "Jake",
+      "type": "dog"
+    },
+    {
+      "name": "Blacky",
+      "type": "bird"
+    }
+  ]
+}
+{
+  "animals": [
+    {
+      "name": "Test",
+      "type": "test"
+    }
+  ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/test.fix
@@ -1,0 +1,1 @@
+prepend("animals[].*.type", "Big ")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithAsteriskArrayWildcard/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;


### PR DESCRIPTION
I needed a test to check if asterisk is working with `append`/`prepend` in array of objects in context of OERSI. So I created an additional integration test.