### PR TITLE
Add integration test for `add_field` with `$last` wildcard

### DIFF
--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/expected.json
@@ -1,0 +1,13 @@
+{
+  "animals" : [ {
+    "name" : "Jake",
+    "type" : "dog"
+  }, {
+    "name" : "Blacky",
+    "type" : "bird",
+    "key" : "value"
+  } ]
+}
+{
+  "animals" : [ ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/input.json
@@ -1,0 +1,15 @@
+{
+  "animals" : [
+    {
+      "name": "Jake",
+      "type": "dog"
+    },
+    {
+      "name": "Blacky",
+      "type": "bird"
+    }
+  ]
+}
+{
+  "animals" : [ ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/test.fix
@@ -1,0 +1,1 @@
+add_field("animals[].$last.key", "value")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldkIntoArrayOfObjectsWithLastWildcard/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;


### PR DESCRIPTION
#102

Behaviour seems to have changed #102 breaks and master ingores
if there is no object in the array and you use to `add_field` with
`$last` wildcard