### PR TITLE
Implement "strict" mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 /metafix/src/test/resources/org/metafacture/metafix/integration/**/*.err
 /metafix/src/test/resources/org/metafacture/metafix/integration/**/*.out
 /metafix/src/test/resources/org/metafacture/metafix/integration/**/output-*
+!/metafix/src/test/resources/org/metafacture/metafix/integration/**/expected.err

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation "org.metafacture:metamorph:${versions.metafacture}"
 
   testImplementation "nl.jqno.equalsverifier:equalsverifier:${versions.equalsverifier}"
-  testImplementation "org.mockito:mockito-core:${versions.mockito}"
+  testImplementation "org.mockito:mockito-inline:${versions.mockito}"
   testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"
 }
 

--- a/metafix/src/main/java/org/metafacture/metafix/FixProcessException.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixProcessException.java
@@ -19,18 +19,18 @@ package org.metafacture.metafix;
 import org.metafacture.framework.MetafactureException;
 
 /**
- * Indicates dynamic (i.e., data-dependent) issues during Fix execution that
- * should be subject to {@link Metafix.Strictness strictness} handling.
+ * Indicates static (i.e., data-independent) issues with the usage of Fix
+ * expressions.
  *
- * @see FixProcessException
+ * @see FixExecutionException
  */
-public class FixExecutionException extends MetafactureException {
+public class FixProcessException extends MetafactureException {
 
-    public FixExecutionException(final String message) {
+    public FixProcessException(final String message) {
         super(message);
     }
 
-    public FixExecutionException(final String message, final Throwable cause) {
+    public FixProcessException(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * Transforms a data stream sent via the {@link StreamReceiver} interface. Use
@@ -60,6 +61,8 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     public static final String FIX_EXTENSION = ".fix";
     public static final String VAR_END = "]";
     public static final String VAR_START = "$[";
+
+    public static final Strictness DEFAULT_STRICTNESS = Strictness.PROCESS;
 
     public static final Map<String, String> NO_VARS = Collections.emptyMap();
 
@@ -79,6 +82,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     private List<Value> entities = new ArrayList<>();
     private Record currentRecord = new Record();
     private StreamReceiver outputStreamReceiver;
+    private Strictness strictness = DEFAULT_STRICTNESS;
     private String fixFile;
     private String recordIdentifier;
     private int entityCount;
@@ -323,6 +327,60 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     @Override
     public String putValue(final String mapName, final String key, final String value) {
         return maps.computeIfAbsent(mapName, k -> new HashMap<>()).put(key, value);
+    }
+
+    public void setStrictness(final Strictness strictness) {
+        this.strictness = strictness != null ? strictness : DEFAULT_STRICTNESS;
+    }
+
+    public Strictness getStrictness() {
+        return strictness;
+    }
+
+    public enum Strictness {
+
+        /**
+         * Aborts process by throwing an exception.
+         */
+        PROCESS {
+            @Override
+            protected void handleInternal(final FixExecutionException exception, final Record record) {
+                throw exception;
+            }
+        },
+
+        /**
+         * Ignores (skips) record and logs an error.
+         */
+        RECORD {
+            @Override
+            protected void handleInternal(final FixExecutionException exception, final Record record) {
+                log(exception, LOG::error);
+                record.setReject(true); // TODO: Skip remaining expressions?
+            }
+        },
+
+        /**
+         * Ignores (skips) expression and logs a warning.
+         */
+        EXPRESSION {
+            @Override
+            protected void handleInternal(final FixExecutionException exception, final Record record) {
+                log(exception, LOG::warn);
+            }
+        };
+
+        public void handle(final FixExecutionException exception, final Record record) {
+            LOG.debug("Current record: {}", record);
+            handleInternal(exception, record);
+        }
+
+        protected abstract void handleInternal(FixExecutionException exception, Record record);
+
+        protected void log(final FixExecutionException exception, final BiConsumer<String, Throwable> logger) {
+            logger.accept(exception.getMessage(), exception.getCause());
+        }
+
     }
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -159,7 +159,7 @@ public class MetafixLookupTest {
     public void shouldNotLookupInRelativeExternalFileMapFromInlineScript() {
         final String mapFile = "../maps/test.csv";
 
-        MetafixTestHelpers.assertThrowsCause(IllegalArgumentException.class, "Cannot resolve relative path: " + mapFile, () ->
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Cannot resolve relative path: " + mapFile, () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     LOOKUP + " '" + mapFile + "')"
                 ),
@@ -299,7 +299,7 @@ public class MetafixLookupTest {
 
     @Test
     public void shouldFailLookupInUnknownExternalMap() {
-        MetafixTestHelpers.assertThrowsCause(MorphExecutionException.class, "File not found: testMap.csv", () ->
+        MetafixTestHelpers.assertProcessException(MorphExecutionException.class, "File not found: testMap.csv", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     LOOKUP + " 'testMap.csv')"
                 ),

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -160,7 +160,7 @@ public class MetafixMethodTest {
 
     @Test
     public void shouldNotCapitalizeArray() {
-        MetafixTestHelpers.assertThrowsCause(IllegalStateException.class, "Expected String, got Array", () ->
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected String, got Array", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "capitalize('title')"
                 ),
@@ -431,7 +431,7 @@ public class MetafixMethodTest {
 
     @Test
     public void parseTextEscapedGroups() {
-        MetafixTestHelpers.assertThrowsCause(IllegalArgumentException.class, "No group with name <c>", () ->
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "No group with name <c>", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "parse_text(data, '(?<a>.)(.)\\\\(?<c>.\\\\)')"
                 ),
@@ -448,7 +448,7 @@ public class MetafixMethodTest {
 
     @Test
     public void parseTextQuotedGroups() {
-        MetafixTestHelpers.assertThrowsCause(IllegalArgumentException.class, "No group with name <c>", () ->
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "No group with name <c>", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "parse_text(data, '(?<a>.)(.)\\\\Q(?<c>.)\\\\E')"
                 ),
@@ -669,7 +669,7 @@ public class MetafixMethodTest {
     @Test
     // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldNotAppendValueToArray() {
-        MetafixTestHelpers.assertThrowsCause(IllegalStateException.class, "Expected String, got Array", () ->
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected String, got Array", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "append('animals[]', ' is cool')"
                 ),
@@ -691,7 +691,7 @@ public class MetafixMethodTest {
     @Test
     // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldNotAppendValueToHash() {
-        MetafixTestHelpers.assertThrowsCause(IllegalStateException.class, "Expected String, got Hash", () ->
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected String, got Hash", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "append('animals', ' is cool')"
                 ),
@@ -1126,7 +1126,7 @@ public class MetafixMethodTest {
     @Test
     // See https://github.com/metafacture/metafacture-fix/issues/100
     public void shouldNotPrependValueToArray() {
-        MetafixTestHelpers.assertThrowsCause(IllegalStateException.class, "Expected String, got Array", () ->
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected String, got Array", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "prepend('animals[]', 'cool ')"
                 ),
@@ -1592,7 +1592,7 @@ public class MetafixMethodTest {
 
     @Test
     public void shouldFailToSortNumericallyWithInvalidNumber() {
-        MetafixTestHelpers.assertThrowsCause(NumberFormatException.class, "For input string: \"x\"", () ->
+        MetafixTestHelpers.assertExecutionException(NumberFormatException.class, "For input string: \"x\"", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "sort_field(numbers, numeric: 'true')"
                 ),

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1083,7 +1083,7 @@ public class MetafixRecordTest {
     }
 
     private void assertThrowsOnEmptyRecord(final String index) {
-        MetafixTestHelpers.assertThrowsCause(IllegalArgumentException.class, "Using ref, but can't find: " + index + " in: {}", () -> {
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Using ref, but can't find: " + index + " in: {}", () -> {
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "add_field('animals[]." + index + ".kind','nice')"
                 ),
@@ -2150,7 +2150,7 @@ public class MetafixRecordTest {
 
     @Test
     public void shouldNotAccessArrayImplicitly() {
-        MetafixTestHelpers.assertThrowsCause(IllegalStateException.class, "Expected String, got Array", () ->
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected String, got Array", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "upcase('name')"
                 ),

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
@@ -45,8 +45,12 @@ public final class MetafixTestHelpers {
     private MetafixTestHelpers() {
     }
 
-    public static void assertThrowsCause(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
+    public static void assertExecutionException(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
         assertThrows(FixExecutionException.class, expectedClass, expectedMessage, executable, UnaryOperator.identity());
+    }
+
+    public static void assertProcessException(final Class<?> expectedClass, final String expectedMessage, final Executable executable) {
+        assertThrows(FixProcessException.class, expectedClass, expectedMessage, executable, UnaryOperator.identity());
     }
 
     public static void assertThrows(final Class<? extends Throwable> expectedClass, final String expectedMessage, final Executable executable) {

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/expected.err
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/expected.err
@@ -1,0 +1,2 @@
+^Exception in thread "main" org\.metafacture\.metafix\.FixExecutionException: Error while executing Fix expression \(at file:.*/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/test\.fix, line 2\): upcase\("data"\)$
+^Caused by: java\.lang\.IllegalStateException: Expected String, got Array$

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/input.json
@@ -1,0 +1,3 @@
+{"data":"foo"}
+{"data":"foo","data":"bar"}
+{"data":"bar"}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/test.fix
@@ -1,0 +1,3 @@
+add_field("before", "")
+upcase("data")
+add_field("after", "")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnExecutionException/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix", strictness="process")
+|encode-json
+|write(FLUX_DIR + "output-metafix.json")
+;

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/expected.err
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/expected.err
@@ -1,0 +1,2 @@
+^Exception in thread "main" org\.metafacture\.metafix\.FixProcessException: Error while executing Fix expression \(at file:.*/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/test\.fix, line 2\): foo\(\)$
+^Caused by: java\.lang\.IllegalArgumentException: No enum constant org\.metafacture\.metafix\.FixMethod.foo$

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/input.json
@@ -1,0 +1,3 @@
+{"data":"foo"}
+{"data":"foo","data":"bar"}
+{"data":"bar"}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/test.fix
@@ -1,0 +1,3 @@
+add_field("before", "")
+foo()
+add_field("after", "")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix", strictness="expression")
+|encode-json
+|write(FLUX_DIR + "output-metafix.json")
+;

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/expected.json
@@ -1,0 +1,14 @@
+{
+  "before" : "",
+  "data" : "FOO",
+  "after" : ""
+}
+{
+  "before" : "",
+  "after" : ""
+}
+{
+  "before" : "",
+  "data" : "BAR",
+  "after" : ""
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/input.json
@@ -1,0 +1,3 @@
+{"data":"foo"}
+{"data":"foo","data":"bar"}
+{"data":"bar"}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/test.fix
@@ -1,0 +1,3 @@
+add_field("before", "")
+upcase("data")
+add_field("after", "")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipExpressionOnExecutionException/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix", strictness="expression")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/expected.json
@@ -1,0 +1,10 @@
+{
+  "before" : "",
+  "data" : "FOO",
+  "after" : ""
+}
+{
+  "before" : "",
+  "data" : "BAR",
+  "after" : ""
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/input.json
@@ -1,0 +1,3 @@
+{"data":"foo"}
+{"data":"foo","data":"bar"}
+{"data":"bar"}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/test.fix
@@ -1,0 +1,3 @@
+add_field("before", "")
+upcase("data")
+add_field("after", "")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessSkipRecordOnExecutionException/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix", strictness="record")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;


### PR DESCRIPTION
Resolves #192.

Levels of strictness:
    
- `PROCESS`: Abort process by throwing an exception. This is the current behaviour and the new default.
- `RECORD`: Ignore (skip) failed record and log an error.
- `EXPRESSION`: Ignore (skip) failed expression and log a warning.
    
Introduces `FixProcessException` to differentiate from `FixExecutionException`: The latter indicating potentially data-dependent issues that should be subject to strictness handling, while the former should only refer to static issues with the usage of Fix expressions.

Areas for future work:

- Escalation strategy: Once `n` expressions have failed, fail the record; once `n` records have failed, fail the process.
- Possibly Fix-internal configuration mechanism (#59).
- Expression grouping ([`maybe()` bind](https://metacpan.org/pod/Catmandu::Fix::Bind::maybe)).

~~(NOTE: We can't test for expected exceptions/errors in integration tests yet.)~~ (Resolved by e167bbe.)