### PR TITLE
Separate Fix expression interpretation from record data transformation.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixBind.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixBind.java
@@ -17,7 +17,6 @@
 package org.metafacture.metafix;
 
 import org.metafacture.metafix.api.FixContext;
-import org.metafacture.metafix.fix.Expression;
 
 import java.util.List;
 import java.util.Map;
@@ -26,8 +25,7 @@ public enum FixBind implements FixContext {
 
     list {
         @Override
-        public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final List<Expression> expressions) {
-            final RecordTransformer recordTransformer = metafix.getRecordTransformer();
+        public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {
             final String scopeVariable = options.get("var");
             Value.asList(record.get(options.get("path")), a -> {
                 for (int i = 0; i < a.size(); ++i) {
@@ -36,7 +34,7 @@ public enum FixBind implements FixContext {
                     // with var -> keep full record in scope, add the var:
                     if (scopeVariable != null) {
                         record.put(scopeVariable, value);
-                        recordTransformer.process(expressions);
+                        recordTransformer.transform(record);
                         record.remove(scopeVariable);
                     }
                     // w/o var -> use the currently bound value as the record:
@@ -48,10 +46,7 @@ public enum FixBind implements FixContext {
                                 final Record scopeRecord = new Record();
                                 scopeRecord.addAll(h);
 
-                                recordTransformer.setRecord(scopeRecord);
-                                recordTransformer.process(expressions);
-                                recordTransformer.setRecord(record);
-
+                                recordTransformer.transform(scopeRecord);
                                 a.set(index, new Value(scopeRecord));
                             })
                             // TODO: bind to arrays (if that makes sense) and strings (access with '.')

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -17,7 +17,6 @@
 package org.metafacture.metafix;
 
 import org.metafacture.metafix.api.FixFunction;
-import org.metafacture.metafix.fix.Fix;
 import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.maps.FileMap;
 
@@ -25,7 +24,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -52,9 +50,7 @@ public enum FixMethod implements FixFunction {
             // TODO: Catmandu load path
             final String includePath = metafix.resolvePath(includeFile);
 
-            final RecordTransformer recordTransformer = metafix.getRecordTransformer();
-            recordTransformer.setRecord(recordTransformer.transformRecord(
-                        INCLUDE_FIX.computeIfAbsent(includePath, FixStandaloneSetup::parseFix)));
+            metafix.getRecordTransformer(includePath).transform(record);
         }
     },
     nothing {
@@ -498,7 +494,5 @@ public enum FixMethod implements FixFunction {
     private static final String FILEMAP_DEFAULT_SEPARATOR = ",";
 
     private static final Random RANDOM = new Random();
-
-    private static final Map<String, Fix> INCLUDE_FIX = new HashMap<>();
 
 }

--- a/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
+++ b/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
@@ -39,9 +39,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -57,42 +57,32 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
 
     private static final Logger LOG = LoggerFactory.getLogger(RecordTransformer.class);
 
-    private final List<Expression> expressions;
+    private final List<Consumer<Record>> consumers = new LinkedList<>();
     private final Map<String, String> vars;
     private final Metafix metafix;
 
-    private Record record;
+    private Supplier<String> currentMessageSupplier;
 
     /*package-private*/ RecordTransformer(final Metafix metafix, final Fix fix) {
         this(metafix, fix.getElements());
     }
 
     private RecordTransformer(final Metafix metafix, final List<Expression> expressions) {
-        this.expressions = expressions;
         this.metafix = metafix;
         vars = metafix.getVars();
-    }
 
-    public void transform(final Record currentRecord) {
-        this.record = currentRecord;
-        process(expressions);
-    }
-
-    private void process(final List<Expression> currentExpressions) {
-        currentExpressions.forEach(e -> {
-            final List<String> params = resolveParams(e.getParams());
-
+        expressions.forEach(e -> {
             if (e instanceof Do) {
-                processDo((Do) e, params);
+                processDo((Do) e);
             }
             else if (e instanceof If) {
-                processIf((If) e, params);
+                processIf((If) e);
             }
             else if (e instanceof Unless) {
-                processUnless((Unless) e, params);
+                processUnless((Unless) e);
             }
             else if (e instanceof MethodCall) {
-                processFunction((MethodCall) e, params);
+                processFunction((MethodCall) e);
             }
             else {
                 throw new FixProcessException(executionExceptionMessage(e));
@@ -100,64 +90,80 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
         });
     }
 
-    private void processDo(final Do expression, final List<String> params) {
-        processExpression(expression, name -> {
-            final FixContext context = getInstance(name, FixContext.class, FixBind::valueOf);
-            context.execute(metafix, record, params, options(expression.getOptions()), new RecordTransformer(metafix, expression.getElements()));
+    public void transform(final Record record) {
+        consumers.forEach(consumer -> {
+            final FixExecutionException exception = tryRun(() -> consumer.accept(record));
+
+            if (exception != null) {
+                metafix.getStrictness().handle(exception, record);
+            }
         });
-
-        // TODO, possibly: use morph collectors here
-        // final CollectFactory collectFactory = new CollectFactory();
-        // final Map<String, String> attributes = resolvedAttributeMap(params, expression.getOptions());
-        // final Collect collect = collectFactory.newInstance(expression.getName(), attributes);
     }
 
-    private void processIf(final If expression, final List<String> params) {
-        final ElsIf elseIfExpression = expression.getElseIf();
-        final Else elseExpression = expression.getElse();
+    private void processDo(final Do expression) {
+        processFix(() -> executionExceptionMessage(expression), () -> {
+            final FixContext context = getInstance(expression.getName(), FixContext.class, FixBind::valueOf);
+            final RecordTransformer recordTransformer = new RecordTransformer(metafix, expression.getElements());
 
-        if (testConditional(expression, expression.eResource(), expression.getName(), params)) {
-            process(expression.getElements());
-        }
-        else if (elseIfExpression != null && testConditional(elseIfExpression,
-                    elseIfExpression.eResource(), elseIfExpression.getName(), resolveParams(elseIfExpression.getParams()))) {
-            process(elseIfExpression.getElements());
-        }
-        else if (elseExpression != null) {
-            process(elseExpression.getElements());
-        }
-    }
-
-    private void processUnless(final Unless expression, final List<String> params) {
-        if (!testConditional(expression, expression.eResource(), expression.getName(), params)) {
-            process(expression.getElements());
-        }
-    }
-
-    private boolean testConditional(final EObject object, final Resource resource, final String conditional, final List<String> params) {
-        LOG.debug("<IF>: {} parameters: {}", conditional, params);
-
-        final AtomicBoolean bool = new AtomicBoolean();
-
-        processFix(() -> executionExceptionMessage(object, resource), () -> {
-            final FixPredicate predicate = getInstance(conditional, FixPredicate.class, FixConditional::valueOf);
-            bool.set(predicate.test(metafix, record, params, options(null))); // TODO: options
+            return record -> context.execute(metafix, record, params(expression.getParams()), options(expression.getOptions()), recordTransformer);
         });
-
-        return bool.get();
-
-        // TODO, possibly: use morph functions here (& in processFunction):
-        // final FunctionFactory functionFactory = new FunctionFactory();
-        // functionFactory.registerClass("not_equals", NotEquals.class);
-        // functionFactory.registerClass("replace_all", Replace.class);
-        // final Function function = functionFactory.newInstance(conditional,
-        // resolvedAttributeMap(params, theIf.getOptions()));
     }
 
-    private void processFunction(final MethodCall expression, final List<String> params) {
-        processExpression(expression, name -> {
-            final FixFunction function = getInstance(name, FixFunction.class, FixMethod::valueOf);
-            function.apply(metafix, record, params, options(expression.getOptions()));
+    private void processIf(final If ifExpression) {
+        final ElsIf elseIfExpression = ifExpression.getElseIf();
+        final Else elseExpression = ifExpression.getElse();
+
+        final Supplier<String> elseIfMessageSupplier = () -> executionExceptionMessage(elseIfExpression, elseIfExpression.eResource());
+        final Supplier<String> elseMessageSupplier = () -> executionExceptionMessage(elseExpression, elseExpression.eResource());
+
+        processFix(() -> executionExceptionMessage(ifExpression, ifExpression.eResource()), () -> {
+            final FixPredicate ifPredicate = getInstance(ifExpression.getName(), FixPredicate.class, FixConditional::valueOf);
+            final FixPredicate elseIfPredicate = elseIfExpression != null ? getInstance(elseIfExpression.getName(), FixPredicate.class, FixConditional::valueOf) : null;
+
+            final RecordTransformer ifTransformer = new RecordTransformer(metafix, ifExpression.getElements());
+            final RecordTransformer elseIfTransformer = elseIfExpression != null ? new RecordTransformer(metafix, elseIfExpression.getElements()) : null;
+            final RecordTransformer elseTransformer = elseExpression != null ? new RecordTransformer(metafix, elseExpression.getElements()) : null;
+
+            return record -> {
+                if (ifPredicate.test(metafix, record, params(ifExpression.getParams()), options(null))) { // TODO: options
+                    ifTransformer.transform(record);
+                }
+                else {
+                    if (elseIfExpression != null) {
+                        currentMessageSupplier = elseIfMessageSupplier;
+
+                        if (elseIfPredicate.test(metafix, record, params(elseIfExpression.getParams()), options(null))) { // TODO: options
+                            elseIfTransformer.transform(record);
+                            return;
+                        }
+                    }
+
+                    if (elseExpression != null) {
+                        currentMessageSupplier = elseMessageSupplier;
+                        elseTransformer.transform(record);
+                    }
+                }
+            };
+        });
+    }
+
+    private void processUnless(final Unless expression) {
+        processFix(() -> executionExceptionMessage(expression, expression.eResource()), () -> {
+            final FixPredicate predicate = getInstance(expression.getName(), FixPredicate.class, FixConditional::valueOf);
+            final RecordTransformer recordTransformer = new RecordTransformer(metafix, expression.getElements());
+
+            return record -> {
+                if (!predicate.test(metafix, record, params(expression.getParams()), options(null))) { // TODO: options
+                    recordTransformer.transform(record);
+                }
+            };
+        });
+    }
+
+    private void processFunction(final MethodCall expression) {
+        processFix(() -> executionExceptionMessage(expression), () -> {
+            final FixFunction function = getInstance(expression.getName(), FixFunction.class, FixMethod::valueOf);
+            return record -> function.apply(metafix, record, params(expression.getParams()), options(expression.getOptions()));
         });
     }
 
@@ -165,18 +171,24 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
         return name.contains(".") ? ReflectionUtil.loadClass(name, baseType).newInstance() : enumFunction.apply(name);
     }
 
-    private void processExpression(final Expression expression, final Consumer<String> consumer) {
-        processFix(() -> executionExceptionMessage(expression), () -> consumer.accept(expression.getName()));
-    }
+    private void processFix(final Supplier<String> messageSupplier, final Supplier<Consumer<Record>> consumerSupplier) {
+        currentMessageSupplier = messageSupplier;
 
-    private void processFix(final Supplier<String> messageSupplier, final Runnable runnable) {
-        final FixExecutionException exception = tryRun(messageSupplier, runnable);
+        final FixExecutionException exception = tryRun(() -> {
+            final Consumer<Record> consumer = consumerSupplier.get();
+
+            consumers.add(record -> {
+                currentMessageSupplier = messageSupplier;
+                consumer.accept(record);
+            });
+        });
+
         if (exception != null) {
-            metafix.getStrictness().handle(exception, record);
+            throw exception;
         }
     }
 
-    private FixExecutionException tryRun(final Supplier<String> messageSupplier, final Runnable runnable) { // checkstyle-disable-line ReturnCount
+    private FixExecutionException tryRun(final Runnable runnable) { // checkstyle-disable-line ReturnCount
         try {
             runnable.run();
         }
@@ -187,11 +199,12 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
             return e; // TODO: Add nesting information?
         }
         catch (final IllegalStateException | NumberFormatException e) {
-            return new FixExecutionException(messageSupplier.get(), e);
+            return new FixExecutionException(currentMessageSupplier.get(), e);
         }
         catch (final RuntimeException e) { // checkstyle-disable-line IllegalCatch
-            throw new FixProcessException(messageSupplier.get(), e);
+            throw new FixProcessException(currentMessageSupplier.get(), e);
         }
+
         return null;
     }
 
@@ -206,12 +219,12 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
                 resource.getURI(), node.getStartLine(), NodeModelUtils.getTokenText(node));
     }
 
-    private List<String> resolveParams(final List<String> params) {
-        return params.stream().map(this::resolveVars).collect(Collectors.toList());
-    }
-
     private String resolveVars(final String value) {
         return value == null ? null : StringUtil.format(value, Metafix.VAR_START, Metafix.VAR_END, false, vars);
+    }
+
+    private List<String> params(final List<String> params) {
+        return params.stream().map(this::resolveVars).collect(Collectors.toList());
     }
 
     private Map<String, String> options(final Options options) {

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixContext.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixContext.java
@@ -18,7 +18,7 @@ package org.metafacture.metafix.api;
 
 import org.metafacture.metafix.Metafix;
 import org.metafacture.metafix.Record;
-import org.metafacture.metafix.fix.Expression;
+import org.metafacture.metafix.RecordTransformer;
 
 import java.util.List;
 import java.util.Map;
@@ -26,6 +26,6 @@ import java.util.Map;
 @FunctionalInterface
 public interface FixContext {
 
-    void execute(Metafix metafix, Record record, List<String> params, Map<String, String> options, List<Expression> expressions);
+    void execute(Metafix metafix, Record record, List<String> params, Map<String, String> options, RecordTransformer recordTransformer);
 
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -1012,4 +1012,61 @@ public class MetafixIfTest {
         );
     }
 
+    @Test
+    public void shouldIncludeLocationAndTextInProcessExceptionInConditional() {
+        final String text1 = "elsif exists()";
+        final String text2 = "nothing()";
+        final String message = "Error while executing Fix expression (at FILE, line 3): " + text1 + " " + text2;
+
+        MetafixTestHelpers.assertThrows(FixProcessException.class, s -> s.replaceAll("file:/.+?\\.fix", "FILE"), message, () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "if exists('animal')",
+                    "nothing()",
+                    text1,
+                    text2,
+                    "end"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("animals");
+                    i.literal("1", "dog");
+                    i.literal("2", "cat");
+                    i.literal("3", "zebra");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldIncludeLocationAndTextInProcessExceptionInBody() {
+        final String text = "add_field()";
+        final String message = "Error while executing Fix expression (at FILE, line 4): " + text;
+
+        MetafixTestHelpers.assertThrows(FixProcessException.class, s -> s.replaceAll("file:/.+?\\.fix", "FILE"), message, () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "if exists('animal')",
+                    "nothing()",
+                    "elsif exists('animals')",
+                    text,
+                    "end"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("animals");
+                    i.literal("1", "dog");
+                    i.literal("2", "cat");
+                    i.literal("3", "zebra");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
 }

--- a/metafix/src/test/java/org/metafacture/metafix/util/TestContext.java
+++ b/metafix/src/test/java/org/metafacture/metafix/util/TestContext.java
@@ -18,9 +18,9 @@ package org.metafacture.metafix.util;
 
 import org.metafacture.metafix.Metafix;
 import org.metafacture.metafix.Record;
+import org.metafacture.metafix.RecordTransformer;
 import org.metafacture.metafix.Value;
 import org.metafacture.metafix.api.FixContext;
-import org.metafacture.metafix.fix.Expression;
 
 import java.util.List;
 import java.util.Map;
@@ -31,9 +31,9 @@ public class TestContext implements FixContext {
     }
 
     @Override
-    public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final List<Expression> expressions) {
+    public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {
         record.add("BEFORE", new Value(params.get(0)));
-        metafix.getRecordTransformer().process(expressions);
+        recordTransformer.transform(record);
         record.add("AFTER", new Value(options.get("data")));
     }
 

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/expected.err
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/expected.err
@@ -1,2 +1,3 @@
-^Exception in thread "main" org\.metafacture\.metafix\.FixProcessException: Error while executing Fix expression \(at file:.*/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/test\.fix, line 2\): foo\(\)$
+^Exception in thread "main" org\.metafacture\.commons\.reflection\.ReflectionException: class could not be instantiated: class org\.metafacture\.metafix\.Metafix$
+^Caused by: org\.metafacture\.metafix\.FixProcessException: Error while executing Fix expression \(at file:.*/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/strictnessAbortProcessOnProcessException/test\.fix, line 2\): foo\(\)$
 ^Caused by: java\.lang\.IllegalArgumentException: No enum constant org\.metafacture\.metafix\.FixMethod.foo$


### PR DESCRIPTION
Everything that is data-independent should be done only once at initialization time. IOW: Perform as little work as possible per record.

Behaviour changes:

1. Records are modified in-place instead of passing around and replacing (shallow) copies of records. Doesn't seem to have any practical consequences, though.
2. Fix definitions are interpreted at initialization time, thus potentially throwing exceptions immediately instead of later during record processing. Effect can be observed in integration test `script/fromJson/toJson/strictnessAbortProcessOnProcessException`.

Initial measurements indicate a speedup of about 10 % with a sufficiently complex mapping; more benchmark results ~~to be added later (@fsteeg: But you can already review the technical details if you like)~~ below.

Related to #207.