### PR TITLE
 Handle $first, $last for find and replace in arrays (#135, #144)

### DIFF
--- a/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
@@ -19,11 +19,9 @@ package org.metafacture.metafix;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 
-@ExtendWith(MetafixToDo.Extension.class)
 public class HashValueTest {
 
     private static final String FIELD = "field";
@@ -394,7 +392,6 @@ public class HashValueTest {
     }
 
     @Test
-    @MetafixToDo("Expected String, got Array")
     public void shouldFindArrayWildcard() {
         shouldFindArray("$last");
     }
@@ -412,7 +409,6 @@ public class HashValueTest {
     }
 
     @Test
-    @MetafixToDo("Expected String, got Array")
     public void shouldFindArrayWildcardSubfield() {
         shouldFindArraySubfield("$last");
     }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -1069,4 +1069,69 @@ public class MetafixIfTest {
         );
     }
 
+    @Test
+    public void ifOnNonExistingIndexInArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "if exists('animals[].2')",
+                "  copy_field('animals[].2', 'animals2')",
+                "end"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.literal("2", "elefant");
+                i.endEntity();
+                i.endRecord();
+                i.startRecord("2");
+                i.startEntity("animals[]");
+                i.literal("1", "dog");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "dog");
+                o.get().literal("2", "elefant");
+                o.get().endEntity();
+                o.get().literal("animals2", "elefant");
+                o.get().endRecord();
+                o.get().startRecord("2");
+                o.get().startEntity("animals[]");
+                o.get().literal("1", "dog");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void ifOnNonExistingIndexInRepeatedField() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "if exists('animal.2')",
+                "  copy_field('animal.2', 'animal2')",
+                "end"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("animal", "dog");
+                i.literal("animal", "elefant");
+                i.endRecord();
+                i.startRecord("2");
+                i.literal("animal", "dog");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("animal", "dog");
+                o.get().literal("animal", "elefant");
+                o.get().literal("animal2", "elefant");
+                o.get().endRecord();
+                o.get().startRecord("2");
+                o.get().literal("animal", "dog");
+                o.get().endRecord();
+            }
+        );
+    }
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -2051,7 +2051,6 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/135")
     public void shouldReplaceAllRegexesInArrayByArrayWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "replace_all('names.$last', 'a', 'X')"
@@ -2103,7 +2102,6 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @MetafixToDo("See https://github.com/metafacture/metafacture-fix/issues/135")
     public void shouldReplaceAllRegexesInArraySubFieldByArrayWildcard() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "replace_all('names[].$last.name', 'a', 'X')"

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithFirstArrayWildcard/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithFirstArrayWildcard/test.fix
@@ -1,1 +1,1 @@
-append("animals[].$last.type", " is cool")
+append("animals[].$first.type", " is cool")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithFirstArrayWildcard/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithFirstArrayWildcard/todo.txt
@@ -1,1 +1,0 @@
-See issue #144

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithLastArrayWildcard/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithLastArrayWildcard/test.fix
@@ -1,1 +1,1 @@
-append("animals[].$first.type", " is cool")
+append("animals[].$last.type", " is cool")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithLastArrayWildcard/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/appendArrayOfObjectsWithLastArrayWildcard/todo.txt
@@ -1,1 +1,0 @@
-See issue #144

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithFirstArrayWildcard/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithFirstArrayWildcard/todo.txt
@@ -1,1 +1,0 @@
-See issue #144

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithLastArrayWildcard/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithLastArrayWildcard/test.fix
@@ -1,1 +1,1 @@
-append("animals[].$last.type", "Big ")
+prepend("animals[].$last.type", "Big ")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithLastArrayWildcard/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/prependArrayOfObjectsWithLastArrayWildcard/todo.txt
@@ -1,1 +1,0 @@
-See issue #144

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/replace_allInSubfieldOfArrayOfObjectsWithLastWildcard/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/replace_allInSubfieldOfArrayOfObjectsWithLastWildcard/todo.txt
@@ -1,1 +1,0 @@
-See issue #144


### PR DESCRIPTION
Resolves #135, resolves #144.

Contains some potential performance improvements (e.g. 5d3168e3e73897350eaf00165488ebeaa687bbfe), simple tests with 10k records in limetrans (`./gradlew -Dhbz.limetrans.type=fix testAlmaHBZ`) seem to point to a slight improvement (5-10%).