### PR TITLE
Optimize path wildcard matching for literal (non-wildcard) field names.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -462,6 +462,7 @@ public class Value {
      */
     public static class Hash extends AbstractValueType {
 
+        // NOTE: Keep in sync with `WildcardTrie`/`SimpleRegexTrie` implementation in metafacture-core.
         private static final Matcher PATTERN_MATCHER = Pattern.compile("[*?|]|\\[[^\\]]").matcher("");
 
         private static final Map<String, Map<String, Boolean>> TRIE_CACHE = new HashMap<>();

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -33,6 +33,8 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -460,6 +462,8 @@ public class Value {
      */
     public static class Hash extends AbstractValueType {
 
+        private static final Matcher PATTERN_MATCHER = Pattern.compile("[*?|]|\\[[^\\]]").matcher("");
+
         private static final Map<String, Map<String, Boolean>> TRIE_CACHE = new HashMap<>();
         private static final SimpleRegexTrie<String> TRIE = new SimpleRegexTrie<>();
 
@@ -697,12 +701,17 @@ public class Value {
         }
 
         private <T> T matchFields(final String pattern, final BiFunction<Stream<String>, Predicate<String>, T> function) {
-            final Map<String, Boolean> matcher = TRIE_CACHE.computeIfAbsent(pattern, k -> {
-                TRIE.put(k, k);
-                return new HashMap<>();
-            });
+            if (PATTERN_MATCHER.reset(pattern).find()) {
+                final Map<String, Boolean> matcher = TRIE_CACHE.computeIfAbsent(pattern, k -> {
+                    TRIE.put(k, k);
+                    return new HashMap<>();
+                });
 
-            return function.apply(map.keySet().stream(), f -> matcher.computeIfAbsent(f, k -> TRIE.get(k).contains(pattern)));
+                return function.apply(map.keySet().stream(), f -> matcher.computeIfAbsent(f, k -> TRIE.get(k).contains(pattern)));
+            }
+            else {
+                return function.apply(Stream.of(pattern), map::containsKey);
+            }
         }
 
     }


### PR DESCRIPTION
Matching path wildcard patterns against record fields is still a major bottleneck (see [#207 (comment)](https://github.com/metafacture/metafacture-fix/issues/207#issuecomment-1106645612) for the latest analysis and 90cbde4 for the preceding optimization). We can save a considerable amount of CPU time (with a complex real-world mapping) by simply skipping the pattern matching process for literal (i.e., non-wildcard) field names.

NOTE: Runs potential risk of diverging from `WildcardTrie`/`SimpleRegexTrie` implementation.

Related to #207.

---

Benchmark results:

| Alma records        | Runtime @ 1933b59 | Runtime @ f64cbde |   Boost |
|:--------------------|------------------:|------------------:|--------:|
| 3.5k                |               40s |               22s | -46.14% |
| 1.6m (out of 23.5m) |          8h14m27s |           4h20m4s | -47.40% |

JMH:

| Benchmark   | (fixDef) | (input)    |   Score @ 1933b59 |   Score @ f64cbde | Units   |    Boost |
|:------------|:---------|:-----------|------------------:|------------------:|:--------|---------:|
| Baseline    | N/A      | N/A        | 3034.791 ± 10.945 |  3039.124 ± 2.020 | ops/us  |   +0.14% |
| FixParse    | nothing  | N/A        |    34.920 ± 0.857 |    34.996 ± 0.938 | ops/s   |   +0.22% |
| FixParse    | alma     | N/A        |    25.420 ± 0.650 |    25.538 ± 0.681 | ops/s   |   +0.46% |
| Metafix     | nothing  | empty      | 2262.511 ± 26.366 | 2252.160 ± 51.644 | ops/s   |   -0.46% |
| Metafix     | nothing  | alma-small |    21.299 ± 0.577 |    24.822 ± 2.579 | ops/s   |  +16.54% |
| Metafix     | alma     | empty      |   358.174 ± 5.073 |  420.586 ± 17.838 | ops/s   |  +17.43% |
| Metafix     | alma     | alma-small |     0.999 ± 0.045 |     2.002 ± 0.075 | ops/s   | +100.40% |
| SlowMetafix | nothing  | alma-large |    13.175 ± 0.307 |    15.658 ± 0.934 | ops/min |  +18.85% |
| SlowMetafix | alma     | alma-large |     0.626 ± 0.095 |     1.263 ± 0.014 | ops/min | +101.76% |