### PR TITLE
Fix issue with dollars in var paths when handled as regex

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixPath.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixPath.java
@@ -298,7 +298,7 @@ import java.util.Map;
         return Arrays.copyOfRange(fields, 1, fields.length);
     }
 
-    private enum ReservedField {
+    /*package-private*/ enum ReservedField {
         $append, $first, $last;
 
         private static final Map<String, ReservedField> STRING_TO_ENUM = new HashMap<>();

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -17,6 +17,7 @@
 package org.metafacture.metafix;
 
 import org.metafacture.commons.tries.SimpleRegexTrie;
+import org.metafacture.metafix.FixPath.ReservedField;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -208,7 +209,10 @@ public class Value {
 
     /*package-private*/ Value updatePathRename(final String newName) {
         if (path != null) {
-            path = newName.replaceAll("\\$[^.]+", split(path)[0]);
+            final String basePath = split(path)[0];
+            for (final ReservedField rf : ReservedField.values()) {
+                path = newName.replace(rf.name(), basePath);
+            }
         }
         return this;
     }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -2032,6 +2032,33 @@ public class MetafixMethodTest {
     }
 
     @Test
+    public void shouldCopyBindVarWithDollarAfterLookup() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('@coll[]')",
+                "do list(path: 'a', 'var': '$i')",
+                "  lookup('$i.name')",
+                "  copy_field('$i.name', '@coll[].$append')",
+                "end",
+                "remove_field('a')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("a");
+                i.literal("name", "Dog");
+                i.endEntity();
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("@coll[]");
+                o.get().literal("1", "Dog");
+                f.apply(1).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     // See https://github.com/metafacture/metafacture-fix/issues/121
     public void shouldReplaceAllRegexesInNestedArray() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(


### PR DESCRIPTION
Found via regression in OERSI, see new unit test and https://gitlab.com/oersi/oersi-etl/-/merge_requests/175