### PR TITLE
Add option to emit repeated fields as entities (#147)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ subprojects {
   }
 
   checkstyle {
-    toolVersion '8.30'
+    toolVersion '8.44'
   }
 
   tasks.withType(JavaCompile) {

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -200,7 +200,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
 
     private void emit(final String field, final Value value) {
         Value.asList(value, array -> {
-            final boolean isMulti = (repeatedFieldsToEntities && array.size() > 1) || isArrayName(field); // checkstyle-disable-line UnnecessaryParentheses
+            final boolean isMulti = repeatedFieldsToEntities && array.size() > 1 || isArrayName(field);
             if (isMulti) {
                 outputStreamReceiver.startEntity(field);
             }

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -82,6 +82,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
     private Record currentRecord = new Record();
     private StreamReceiver outputStreamReceiver;
     private Strictness strictness = DEFAULT_STRICTNESS;
+    private boolean repeatedFieldsToEntities;
     private String fixFile;
     private String recordIdentifier;
     private int entityCount;
@@ -199,7 +200,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
 
     private void emit(final String field, final Value value) {
         Value.asList(value, array -> {
-            final boolean isMulti = isArrayName(field);
+            final boolean isMulti = repeatedFieldsToEntities && array.size() > 1 || isArrayName(field);
             if (isMulti) {
                 outputStreamReceiver.startEntity(field);
             }
@@ -347,6 +348,14 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
 
     public Strictness getStrictness() {
         return strictness;
+    }
+
+    public void setRepeatedFieldsToEntities(final boolean repeatedFieldsToEntities) {
+        this.repeatedFieldsToEntities = repeatedFieldsToEntities;
+    }
+
+    public boolean getRepeatedFieldsToEntities() {
+        return repeatedFieldsToEntities;
     }
 
     public enum Strictness {

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -200,7 +200,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps { // checkstyle
 
     private void emit(final String field, final Value value) {
         Value.asList(value, array -> {
-            final boolean isMulti = repeatedFieldsToEntities && array.size() > 1 || isArrayName(field);
+            final boolean isMulti = (repeatedFieldsToEntities && array.size() > 1) || isArrayName(field); // checkstyle-disable-line UnnecessaryParentheses
             if (isMulti) {
                 outputStreamReceiver.startEntity(field);
             }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -2300,10 +2300,11 @@ public class MetafixRecordTest {
 
     @Test
     public void emitEntityForRepeatedField() {
-        MetafixTestHelpers.assertFix(streamReceiver, true, Arrays.asList(
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "nothing()"
             ),
             i -> {
+                i.setRepeatedFieldsToEntities(true);
                 i.startRecord("1");
                 i.literal("name", "max");
                 i.literal("name", "mo");
@@ -2322,10 +2323,11 @@ public class MetafixRecordTest {
 
     @Test
     public void dontEmitEntityForSingleField() {
-        MetafixTestHelpers.assertFix(streamReceiver, true, Arrays.asList(
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "nothing()"
             ),
             i -> {
+                i.setRepeatedFieldsToEntities(true);
                 i.startRecord("1");
                 i.literal("name", "max");
                 i.endRecord();

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -2298,6 +2298,46 @@ public class MetafixRecordTest {
         );
     }
 
+    @Test
+    public void emitEntityForRepeatedField() {
+        MetafixTestHelpers.assertFix(streamReceiver, true, Arrays.asList(
+                "nothing()"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "max");
+                i.literal("name", "mo");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("name");
+                o.get().literal("1", "max");
+                o.get().literal("2", "mo");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void dontEmitEntityForSingleField() {
+        MetafixTestHelpers.assertFix(streamReceiver, true, Arrays.asList(
+                "nothing()"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "max");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "max");
+                o.get().endRecord();
+            }
+        );
+    }
+
     public void shouldNotAccessArrayImplicitly() {
         MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected String, got Array", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
@@ -76,30 +76,36 @@ public final class MetafixTestHelpers {
         Assertions.assertEquals(expectedMessage, operator.apply(actualException.getMessage()));
     }
 
+    public static void assertFix(final StreamReceiver receiver, final boolean repeatedFieldsToEntities, final List<String> fixDef, final Consumer<Metafix> in,
+            final Consumer<Supplier<StreamReceiver>> out) {
+        assertFix(receiver, repeatedFieldsToEntities, fixDef, in, (s, f) -> out.accept(s), Metafix.NO_VARS);
+    }
+
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Consumer<Metafix> in,
             final Consumer<Supplier<StreamReceiver>> out) {
-        assertFix(receiver, fixDef, in, (s, f) -> out.accept(s), Metafix.NO_VARS);
+        assertFix(receiver, false, fixDef, in, (s, f) -> out.accept(s), Metafix.NO_VARS);
     }
 
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Consumer<Metafix> in,
             final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out) {
-        assertFix(receiver, fixDef, in, out, Metafix.NO_VARS);
+        assertFix(receiver, false, fixDef, in, out, Metafix.NO_VARS);
     }
 
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Map<String, String> vars,
             final Consumer<Metafix> in, final Consumer<Supplier<StreamReceiver>> out) {
-        assertFix(receiver, fixDef, in, (s, f) -> out.accept(s), vars);
+        assertFix(receiver, false, fixDef, in, (s, f) -> out.accept(s), vars);
     }
 
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Map<String, String> vars,
             final Consumer<Metafix> in, final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out) {
-        assertFix(receiver, fixDef, in, out, vars);
+        assertFix(receiver, false, fixDef, in, out, vars);
     }
 
-    private static void assertFix(final StreamReceiver receiver, final List<String> fixLines, final Consumer<Metafix> in,
+    private static void assertFix(final StreamReceiver receiver, final boolean repeatedFieldsToEntities, final List<String> fixLines, final Consumer<Metafix> in, // checkstyle-disable-line ParameterNumberCheck
             final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out, final Map<String, String> vars) {
         final String fixString = String.join("\n", fixLines);
         final Metafix metafix = fix(receiver, fixString, vars);
+        metafix.setRepeatedFieldsToEntities(repeatedFieldsToEntities);
         final InOrder ordered = Mockito.inOrder(receiver);
         try {
             in.accept(metafix);

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixTestHelpers.java
@@ -76,36 +76,30 @@ public final class MetafixTestHelpers {
         Assertions.assertEquals(expectedMessage, operator.apply(actualException.getMessage()));
     }
 
-    public static void assertFix(final StreamReceiver receiver, final boolean repeatedFieldsToEntities, final List<String> fixDef, final Consumer<Metafix> in,
-            final Consumer<Supplier<StreamReceiver>> out) {
-        assertFix(receiver, repeatedFieldsToEntities, fixDef, in, (s, f) -> out.accept(s), Metafix.NO_VARS);
-    }
-
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Consumer<Metafix> in,
             final Consumer<Supplier<StreamReceiver>> out) {
-        assertFix(receiver, false, fixDef, in, (s, f) -> out.accept(s), Metafix.NO_VARS);
+        assertFix(receiver, fixDef, in, (s, f) -> out.accept(s), Metafix.NO_VARS);
     }
 
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Consumer<Metafix> in,
             final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out) {
-        assertFix(receiver, false, fixDef, in, out, Metafix.NO_VARS);
+        assertFix(receiver, fixDef, in, out, Metafix.NO_VARS);
     }
 
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Map<String, String> vars,
             final Consumer<Metafix> in, final Consumer<Supplier<StreamReceiver>> out) {
-        assertFix(receiver, false, fixDef, in, (s, f) -> out.accept(s), vars);
+        assertFix(receiver, fixDef, in, (s, f) -> out.accept(s), vars);
     }
 
     public static void assertFix(final StreamReceiver receiver, final List<String> fixDef, final Map<String, String> vars,
             final Consumer<Metafix> in, final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out) {
-        assertFix(receiver, false, fixDef, in, out, vars);
+        assertFix(receiver, fixDef, in, out, vars);
     }
 
-    private static void assertFix(final StreamReceiver receiver, final boolean repeatedFieldsToEntities, final List<String> fixLines, final Consumer<Metafix> in, // checkstyle-disable-line ParameterNumberCheck
+    private static void assertFix(final StreamReceiver receiver, final List<String> fixLines, final Consumer<Metafix> in,
             final BiConsumer<Supplier<StreamReceiver>, IntFunction<StreamReceiver>> out, final Map<String, String> vars) {
         final String fixString = String.join("\n", fixLines);
         final Metafix metafix = fix(receiver, fixString, vars);
-        metafix.setRepeatedFieldsToEntities(repeatedFieldsToEntities);
         final InOrder ordered = Mockito.inOrder(receiver);
         try {
             in.accept(metafix);


### PR DESCRIPTION
Resolves #147, see [Playground example](https://test.metafacture.org/playground/?flux=PG_DATA%0A%7Cdecode-xml%0A%7Chandle-generic-xml%0A%7Cfix%28%22nothing%28%29%22%2CrepeatedFieldsToEntities%3D%22true%22%29%0A%7Cflatten%0A%7Cencode-literals%0A%7Cprint%0A%3B&data=%3C%3Fxml+version%3D%221.0%22%3F%3E%0A%3Crecord%3E%0A++++%3Cfield%3Ea%3C/field%3E%0A++++%3Cfield%3Eb%3C/field%3E%0A%3C/record%3E).