### PR TITLE
Optimize performance bottlenecks in `Value.Hash` and `RecordTransformer`.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Fix.xtext
+++ b/metafix/src/main/java/org/metafacture/metafix/Fix.xtext
@@ -16,13 +16,13 @@ Expression:
 ;
 
 Unless:
-  'unless' name = QualifiedName '(' ( params += (QualifiedName|STRING) ( ',' params += (QualifiedName|STRING) )* )? ')'
+  'unless' name = QualifiedName '(' ( params += (QualifiedName|STRING) ( ',' params += (QualifiedName|STRING) )* ','? )? ( options = Options )? ')'
     elements += Expression*
   'end'
 ;
 
 If:
-  'if' name = QualifiedName '(' ( params += (QualifiedName|STRING) ( ',' params += (QualifiedName|STRING) )* )? ')'
+  'if' name = QualifiedName '(' ( params += (QualifiedName|STRING) ( ',' params += (QualifiedName|STRING) )* ','? )? ( options = Options )? ')'
     elements += Expression*
   elseIf = ElsIf?
   else = Else?
@@ -30,7 +30,7 @@ If:
 ;
 
 ElsIf:
-  'elsif' name = QualifiedName '(' ( params += (QualifiedName|STRING) ( ',' params += (QualifiedName|STRING) )* )? ')'
+  'elsif' name = QualifiedName '(' ( params += (QualifiedName|STRING) ( ',' params += (QualifiedName|STRING) )* ','? )? ( options = Options )? ')'
     elements += Expression*
 ;
 


### PR DESCRIPTION
`Value.Hash`:

- Avoid `Stream` API in hot path.
- Sidestep `WildcardTrie` w.r.t. alternations.
- Guard `SimpleRegexTrie` matching with prefix match.

`RecordTransformer`:

- Extract option building out of the record loop.
- Only resolve variables if actually needed.

This is getting considerably more complex. But the expected speedup is nothing to scoff at either: up to 20 % in real-world scenarios and even up to 80 % in synthetic benchmarks.

NOTE: Adding options to conditionals (see 56e59e6) is orthogonal to the performance optimizations and entirely optional. It just came naturally and simplified the implementation a little.

Related to #207.

[Next up: `Value.TypeMatcher`. While it sure does provide a nice API, it's the top offender now (fills whole top 10 in HPROF CPU profile).]

---

Benchmark results:

| Alma records        | Runtime @ 46fb034 | Runtime @ 85db657 |   Boost |
|:--------------------|------------------:|------------------:|--------:|
| 3.5k                |               18s |               14s | -21.75% |
| 1.6m (out of 23.5m) |          3h31m56s |          2h57m13s | -16.38% |

JMH:

| Benchmark   | (fixDef) | (input)    |   Score @ 46fb034 |   Score @ 85db657 | Units   |   Boost |
|:------------|:---------|:-----------|------------------:|------------------:|:--------|--------:|
| Baseline    | N/A      | N/A        | 3025.642 ± 65.441 |  3037.588 ± 0.671 | ops/us  |  +0.39% |
| FixParse    | nothing  | N/A        |    35.072 ± 0.689 |    35.051 ± 0.638 | ops/s   |  -0.06% |
| FixParse    | alma     | N/A        |    25.670 ± 1.076 |    25.619 ± 0.687 | ops/s   |  -0.20% |
| Metafix     | nothing  | empty      | 2281.691 ± 42.123 | 2323.425 ± 49.548 | ops/s   |  +1.83% |
| Metafix     | nothing  | alma-small |    26.501 ± 0.574 |    28.167 ± 0.317 | ops/s   |  +6.29% |
| Metafix     | alma     | empty      |   421.055 ± 7.323 |   760.975 ± 6.634 | ops/s   | +80.73% |
| Metafix     | alma     | alma-small |     2.027 ± 0.027 |     3.636 ± 0.249 | ops/s   | +79.38% |
| SlowMetafix | nothing  | alma-large |    15.521 ± 0.267 |    17.078 ± 1.170 | ops/min | +10.03% |
| SlowMetafix | alma     | alma-large |     1.239 ± 0.021 |     2.262 ± 0.007 | ops/min | +82.57% |