### PR TITLE
Optimize `TypeMatcher` data structure.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -22,6 +22,7 @@ import org.metafacture.commons.tries.WildcardTrie;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -304,7 +305,7 @@ public class Value {
 
     public static class TypeMatcher {
 
-        private final Set<Type> expected = new HashSet<>();
+        private final Set<Type> expected = EnumSet.noneOf(Type.class);
         private final Value value;
 
         private TypeMatcher(final Value value) {

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -20,9 +20,9 @@ import org.metafacture.commons.tries.SimpleRegexTrie;
 import org.metafacture.commons.tries.WildcardTrie;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -305,8 +305,9 @@ public class Value {
 
     public static class TypeMatcher {
 
-        private final Set<Type> expected = EnumSet.noneOf(Type.class);
         private final Value value;
+
+        private byte expected; // NOTE: Covers at most 7 `Type`s.
 
         private TypeMatcher(final Value value) {
             this.value = value;
@@ -325,20 +326,26 @@ public class Value {
         }
 
         public void orElse(final Consumer<Value> consumer) {
-            if (!expected.contains(value.type)) {
+            if (!expecting(value.type)) {
                 consumer.accept(value);
             }
         }
 
         public void orElseThrow() {
             orElse(v -> {
-                final String types = expected.stream().map(Type::name).collect(Collectors.joining(" or "));
+                final String types = Arrays.stream(Type.values()).filter(this::expecting)
+                    .map(Type::name).collect(Collectors.joining(" or "));
+
                 throw new IllegalStateException("Expected " + types + ", got " + value.type);
             });
         }
 
         private <T> TypeMatcher match(final Type type, final Consumer<T> consumer, final T rawValue) {
-            if (expected.add(type)) {
+            final byte newExpected = (byte) (expected | bit(type));
+
+            if (expected != newExpected) {
+                expected = newExpected;
+
                 if (value.isType(type)) {
                     consumer.accept(rawValue);
                 }
@@ -348,6 +355,14 @@ public class Value {
             else {
                 throw new IllegalStateException("Already expecting " + type);
             }
+        }
+
+        private boolean expecting(final Type type) {
+            return (expected & bit(type)) != 0;
+        }
+
+        private byte bit(final Type type) {
+            return (byte) (1 << type.ordinal());
         }
 
     }


### PR DESCRIPTION
Use either specialized data structure (`EnumSet`) or primitive data type ("bit field") instead of generic `HashSet`.

While the bit field comes out ahead in synthetic benchmarks, the difference isn't as pronounced in real-world scenarios. So we could revert the second commit in favour of a simpler, only slightly less effective approach.

Related to #207 (and inspired by #223).

----

Benchmark results:

- `EnumSet`:

| Alma records        | Runtime @ 42cc86f | Runtime @ 3103856 |   Boost |
|:--------------------|------------------:|------------------:|--------:|
| 3.5k                |           13.242s |           11.772s | -11.10% |
| 1.7m (out of 23.5m) |          2h48m46s |          2h40m17s |  -5.02% |

- "Bit field" (see also #223):

| Alma records        | Runtime @ 42cc86f | Runtime @ c7c824f |   Boost |
|:--------------------|------------------:|------------------:|--------:|
| 3.5k                |           13.242s |           11.908s | -10.07% |
| 1.7m (out of 23.5m) |          2h48m46s |          2h37m28s |  -6.69% |

JMH:

- `EnumSet`:

| Benchmark   | (fixDef) | (input)    |  Score @ 42cc86f |   Score @ 3103856 | Units   |   Boost |
|:------------|:---------|:-----------|-----------------:|------------------:|:--------|--------:|
| Baseline    | N/A      | N/A        | 1588.694 ± 6.744 | 1582.161 ± 10.218 | ops/us  |  -0.41% |
| FixParse    | nothing  | N/A        |   38.540 ± 1.672 |    37.749 ± 1.393 | ops/s   |  -2.05% |
| FixParse    | alma     | N/A        |   26.315 ± 0.747 |    25.993 ± 0.881 | ops/s   |  -1.22% |
| Metafix     | nothing  | empty      | 754.776 ± 40.203 |  762.220 ± 12.314 | ops/s   |  +0.99% |
| Metafix     | nothing  | alma-small |   23.747 ± 1.559 |    31.678 ± 0.858 | ops/s   | +33.40% |
| Metafix     | alma     | empty      | 459.097 ± 20.164 |   488.417 ± 4.326 | ops/s   |  +6.39% |
| Metafix     | alma     | alma-small |    3.387 ± 0.027 |     3.620 ± 0.195 | ops/s   |  +6.88% |
| SlowMetafix | nothing  | alma-large |   15.415 ± 0.243 |    21.718 ± 0.376 | ops/min | +40.89% |
| SlowMetafix | alma     | alma-large |    1.925 ± 0.057 |     2.305 ± 0.054 | ops/min | +19.74% |

- "Bit field" (see also #223):

| Benchmark   | (fixDef) | (input)    |  Score @ 42cc86f |   Score @ c7c824f | Units   |   Boost |
|:------------|:---------|:-----------|-----------------:|------------------:|:--------|--------:|
| Baseline    | N/A      | N/A        | 1588.694 ± 6.744 | 1581.482 ± 15.936 | ops/us  |  -0.45% |
| FixParse    | nothing  | N/A        |   38.540 ± 1.672 |    38.020 ± 1.371 | ops/s   |  -1.35% |
| FixParse    | alma     | N/A        |   26.315 ± 0.747 |    26.499 ± 0.973 | ops/s   |  +0.70% |
| Metafix     | nothing  | empty      | 754.776 ± 40.203 |  771.282 ± 24.386 | ops/s   |  +2.19% |
| Metafix     | nothing  | alma-small |   23.747 ± 1.559 |    34.868 ± 0.212 | ops/s   | +46.83% |
| Metafix     | alma     | empty      | 459.097 ± 20.164 |  486.721 ± 17.697 | ops/s   |  +6.02% |
| Metafix     | alma     | alma-small |    3.387 ± 0.027 |     4.024 ± 0.065 | ops/s   | +18.81% |
| SlowMetafix | nothing  | alma-large |   15.415 ± 0.243 |    23.172 ± 0.418 | ops/min | +50.32% |
| SlowMetafix | alma     | alma-large |    1.925 ± 0.057 |     2.401 ± 0.093 | ops/min | +24.73% |