### PR TITLE
Add `once()` Fix bind.

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,27 @@ do list(path: "<sourceField>", "var": "<variableName>")
 end
 ```
 
+#### `do once`
+
+Executes the statements only once (when the bind is first encountered), not repeatedly for each record.
+
+```perl
+do once()
+  ...
+end
+```
+
+In order to execute multiple blocks only once, tag them with unique identifiers:
+
+```perl
+do once("maps setup")
+  ...
+end
+do once("vars setup")
+  ...
+end
+```
+
 ### Conditionals
 
 Conditionals start with `if` in case of affirming the condition or `unless` rejecting the condition.

--- a/metafix/src/main/java/org/metafacture/metafix/FixBind.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixBind.java
@@ -18,8 +18,11 @@ package org.metafacture.metafix;
 
 import org.metafacture.metafix.api.FixContext;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public enum FixBind implements FixContext {
 
@@ -54,6 +57,17 @@ public enum FixBind implements FixContext {
                     }
                 }
             });
+        }
+    },
+
+    once {
+        private Map<Metafix, Set<String>> executed = new HashMap<>();
+
+        @Override
+        public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {
+            if (executed.computeIfAbsent(metafix, k -> new HashSet<>()).add(params.isEmpty() ? null : params.get(0))) {
+                recordTransformer.transform(record);
+            }
         }
     }
 

--- a/metafix/src/test/resources/org/metafacture/metafix/fixes/once.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/fixes/once.fix
@@ -1,0 +1,5 @@
+add_field(included, "true")
+
+do once()
+  add_field(also_executed, "false")
+end

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/expected.json
@@ -1,0 +1,22 @@
+{
+  "author" : [ {
+    "name" : "RUVIVAL Team",
+    "type" : "Person"
+  }, {
+    "name" : "Samuel Duval",
+    "type" : "Person"
+  } ],
+  "@type" : "test"
+}
+{
+  "author" : [ {
+    "name" : "Jürgen Böhner",
+    "type" : "Person"
+  } ]
+}
+{
+  "author" : [ {
+    "name" : "Peter Müller",
+    "type" : "Person"
+  } ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/input.json
@@ -1,0 +1,23 @@
+{
+  "author" : [ {
+    "name" : "RUVIVAL Team",
+    "type" : "Person"
+  }, {
+    "name" : "Samuel Duval",
+    "type" : "Person"
+  } ]
+}
+{
+  "author" : [ {
+    "name" : "Jürgen Böhner",
+    "type" : "Person"
+  } ]
+}
+{
+  "author" : [ {
+    "name" : "Peter Müller",
+    "type" : "Person"
+  } ]
+}
+
+

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/test.fix
@@ -1,0 +1,3 @@
+do once()
+  add_field("@type","test")
+end

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/bind/fromJson/toJson/onceSimple/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;


### PR DESCRIPTION
Allows to perform setup tasks that don't have to (and/or should not) be repeated for each record. In Limetrans we implemented it as a [custom Fix bind](https://github.com/hbz/limetrans/blob/55da0b6c1a706854637a755caa94e27aacfa8a6e/src/main/java/hbz/limetrans/function/Once.java) (cf. #124), but maybe it's useful generally.

Open question: Currently, the scope is per Fix invocation. Should it be per Fix _file_ instead? (Then we would change `shouldExecuteOnlyOncePerFixInstance()` to `shouldExecuteOnlyOncePerFixFile()`.)

@TobiasNx: Do you also want to do a functional review?