### PR TITLE
Add `debug_record()` Fix function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,37 @@ Copies (or appends to) a field from an existing field.
 copy_field("<sourceField>", "<targetField>")
 ```
 
+##### `debug_record`
+
+Prints the current record either to standard output or to a file.
+
+Parameters:
+
+- `prefix` (optional): Prefix to print before the record. (Default: Empty string)
+
+Options:
+
+- `compression` (file output only): Compression mode. (Default: `auto`)
+- `destination`: Destination to write the record to; may include [format directives](https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax) for counter and record ID (in that order). (Default: `stdout`)
+- `encoding` (file output only): Encoding used by the underlying writer. (Default: `UTF-8`)
+- `footer`: Footer which is output after the record. (Default: `\n`)
+- `header`: Header which is output before the record. (Default: Empty string)
+- `id`: Field name which contains the record ID; if found, will be included before the prefix. (Default: `_id`)
+- `json`: Whether to encode the record as JSON. (Default: `false`)
+- `pretty`: Whether to use pretty printing. (Default: `false`)
+
+```perl
+debug_record(["<prefix>"][, <options>...])
+```
+
+E.g.:
+
+```perl
+debug_record("Before transformation")
+debug_record(destination: "record-%03d.gz", header: "After transformation: ")
+debug_record(destination: "record-%2$s.json", id: "001", json: "true", pretty: "true")
+```
+
 ##### `format`
 
 Replaces the value with a formatted (`sprintf`-like) version.
@@ -369,8 +400,8 @@ Creates (or replaces) a field with the current timestamp.
 
 Options:
 
-- `format`: Date and time pattern as in [java.text.SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html). (Default: Unix timestamp)
-- `timezone`: Time zone as in [java.util.TimeZone](https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html). (Default: UTC)
+- `format`: Date and time pattern as in [java.text.SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html). (Default: `timestamp`)
+- `timezone`: Time zone as in [java.util.TimeZone](https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html). (Default: `UTC`)
 - `language`: Language tag as in [java.util.Locale](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html). (Default: The locale of the host system)
 
 ```perl

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ subprojects {
     versions = [
       'ace':            '1.3.3',
       'equalsverifier': '3.8.2',
+      'jackson':        '2.13.3',
       'jetty':          '9.4.14.v20181114',
       'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.8.2',

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -26,9 +26,11 @@ dependencies {
   runtimeOnly "org.slf4j:slf4j-simple:${versions.slf4j}"
 
   implementation "org.metafacture:metafacture-commons:${versions.metafacture}"
-  implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"
-  implementation "org.metafacture:metafacture-javaintegration:${versions.metafacture}"
   implementation "org.metafacture:metafacture-flowcontrol:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-framework:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-io:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-javaintegration:${versions.metafacture}"
+  implementation "org.metafacture:metafacture-mangling:${versions.metafacture}"
   implementation "org.metafacture:metamorph:${versions.metafacture}"
 
   testImplementation "nl.jqno.equalsverifier:equalsverifier:${versions.equalsverifier}"

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -12,6 +12,7 @@ def passSystemProperties = {
 dependencies {
   implementation "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
   implementation "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
+  implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   implementation "com.google.guava:guava:${versions.guava}"
   implementation "org.slf4j:slf4j-api:${versions.slf4j}"
 

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -16,6 +16,8 @@
 
 package org.metafacture.metafix;
 
+import org.metafacture.framework.StandardEventNames;
+import org.metafacture.io.ObjectWriter;
 import org.metafacture.metafix.api.FixFunction;
 import org.metafacture.metamorph.api.Maps;
 import org.metafacture.metamorph.functions.ISBN;
@@ -23,12 +25,15 @@ import org.metafacture.metamorph.functions.Timestamp;
 import org.metafacture.metamorph.maps.FileMap;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -124,6 +129,53 @@ public enum FixMethod implements FixFunction {
                 record.addNested(newName, newValue);
                 newValue.updatePathRename(newName);
             }));
+        }
+    },
+    debug_record {
+        private final Map<Metafix, LongAdder> scopedCounter = new HashMap<>();
+
+        @Override
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final String destination = options.getOrDefault("destination", ObjectWriter.STDOUT);
+            final Value idValue = record.get(options.getOrDefault("id", StandardEventNames.ID));
+
+            final boolean json = getBoolean(options, "json");
+            final boolean pretty = getBoolean(options, "pretty");
+
+            final String id = Value.isNull(idValue) ? "" : idValue.toString();
+            final String prefix = (id.isEmpty() ? "" : "[" + id + "] ") + (params.isEmpty() ? "" : params.get(0) + ": ");
+
+            final LongAdder counter = scopedCounter.computeIfAbsent(metafix, k -> new LongAdder());
+            counter.increment();
+
+            final ObjectWriter<String> writer = new ObjectWriter<>(String.format(destination, counter.sum(), id));
+
+            withOption(options, "compression", writer::setCompression);
+            withOption(options, "encoding", writer::setEncoding);
+            withOption(options, "footer", writer::setFooter);
+            withOption(options, "header", writer::setHeader);
+
+            boolean written = false;
+
+            if (json) {
+                try {
+                    writer.process(prefix + record.toJson(pretty));
+                    written = true;
+                }
+                catch (final IOException e) {
+                }
+            }
+
+            if (!written) {
+                if (pretty) {
+                    record.forEach((f, v) -> writer.process(prefix + f + "=" + v));
+                }
+                else {
+                    writer.process(prefix + record);
+                }
+            }
+
+            writer.closeStream();
         }
     },
     format {

--- a/metafix/src/main/java/org/metafacture/metafix/Record.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Record.java
@@ -19,6 +19,14 @@ package org.metafacture.metafix;
 import org.metafacture.metafix.FixPath.InsertMode;
 import org.metafacture.metafix.Value.TypeMatcher;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedHashMap;
@@ -108,6 +116,27 @@ public class Record extends Value.Hash {
     public String toString() {
         // TODO: Improve string representation? Include reject status, virtual fields, etc.?
         return super.toString();
+    }
+
+    public String toJson() throws IOException {
+        return toJson(false);
+    }
+
+    public String toJson(final boolean prettyPrinting) throws IOException {
+        final StringWriter writer = new StringWriter();
+        final JsonGenerator jsonGenerator = new JsonFactory().createGenerator(writer);
+        jsonGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
+
+        try {
+            toJson(jsonGenerator);
+        }
+        catch (final UncheckedIOException e) {
+            throw e.getCause();
+        }
+
+        jsonGenerator.flush();
+
+        return writer.toString();
     }
 
     /**


### PR DESCRIPTION
Allows to print the current record during transformation (even at different stages). In Limetrans we implemented it (in a simplified form) as a [custom Fix function](https://github.com/hbz/limetrans/blob/55da0b6c1a706854637a755caa94e27aacfa8a6e/src/main/java/hbz/limetrans/function/DebugRecord.java) (cf. #105), but maybe it's useful generally.

Tests are still missing as I'm unsure how to go about it. Any suggestions?

@TobiasNx: Do you also want to do a functional review?