### PR TITLE
Add integration test for #239

### DIFF
--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/expected.json
@@ -1,0 +1,6 @@
+{
+  "animal_string_Array" : [ "dog" ],
+  "test" : {
+    "1" : "dog"
+  }
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/input.json
@@ -1,0 +1,5 @@
+{
+  "animal_string_Array" : [
+      "dog"
+  ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/test.fix
@@ -1,0 +1,1 @@
+copy_field("animal_string_Array[]", "test")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValueAsIndexedRepeatedField/todo.txt
@@ -1,0 +1,1 @@
+See issue #239


### PR DESCRIPTION
Adds integration test for #239 

It copies an single value array of strings and outputs it as indexed repeated field to show the problematic internal handling that is otherwise [disguised](https://github.com/metafacture/metafacture-fix/blob/d4cd18c7c39384a5596a689f22daaa6117be7f64/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsWithSingleValue).