### PR TITLE
Remove path replacement workarounds, only set and append paths

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -124,7 +124,6 @@ public enum FixMethod implements FixFunction {
                 record.addNested(newName, oldValue); // we're actually aliasing
             }));
         }
-
     },
     format {
         @Override

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -120,11 +120,11 @@ public enum FixMethod implements FixFunction {
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final String oldName = params.get(0);
             final String newName = params.get(1);
-            Value.asList(record.get(oldName), a -> a.forEach(newValue -> {
-                record.addNested(newName, newValue);
-                newValue.updatePathRename(newName);
+            Value.asList(record.get(oldName), a -> a.forEach(oldValue -> {
+                record.addNested(newName, oldValue); // we're actually aliasing
             }));
         }
+
     },
     format {
         @Override

--- a/metafix/src/main/java/org/metafacture/metafix/FixPath.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixPath.java
@@ -64,8 +64,8 @@ import java.util.Map;
     }
 
     /*package-private*/ Value findIn(final Array array) {
-
         final Value result;
+
         if (path.length == 0) {
             result = new Value(array);
         }
@@ -96,8 +96,8 @@ import java.util.Map;
                 result = Value.newArray(a -> array.forEach(v -> a.add(findInValue(v, path))));
             }
         }
-        return result;
 
+        return result;
     }
 
     private Value findInValue(final Value value, final String[] p) {
@@ -124,6 +124,7 @@ import java.util.Map;
 
     /*package-private*/ FixPath to(final Value value, final int i) {
         final FixPath result;
+
         // One *, no matching path: replace with index of current result
         if (countAsterisks() == 1 && !matches(value.getPath())) {
             result = new FixPath(replaceInPath(ASTERISK, i));
@@ -135,6 +136,7 @@ import java.util.Map;
         else {
             result = this;
         }
+
         return result;
     }
 
@@ -154,7 +156,7 @@ import java.util.Map;
         return Arrays.asList(path).stream().filter(s -> s.equals(ASTERISK)).count();
     }
 
-    /* package-private */ enum InsertMode {
+    /*package-private*/ enum InsertMode {
 
         REPLACE {
             @Override
@@ -246,10 +248,10 @@ import java.util.Map;
         }
     }
 
-    /*package-private*/ private Value insertInto(final Array array, final InsertMode mode, final Value newValue) {
+    private Value insertInto(final Array array, final InsertMode mode, final Value newValue) {
         // basic idea: reuse findIn logic here? setIn(findIn(array), newValue)
-
         final String field = path[0];
+
         if (path.length == 1) {
             mode.apply(array, field, newValue);
         }
@@ -261,12 +263,14 @@ import java.util.Map;
                 insertInto(getReferencedValue(array, field, newValue.getPath()), mode, newValue, field, tail(path));
             }
         }
+
         return new Value(array);
     }
 
     /*package-private*/ Value insertInto(final Hash hash, final InsertMode mode, final Value newValue) {
         // basic idea: reuse findIn logic here? setIn(findIn(hash), newValue)
         final String field = path[0];
+
         if (path.length == 1) {
             mode.apply(hash, field, newValue);
         }
@@ -276,11 +280,11 @@ import java.util.Map;
             }
             insertInto(hash.get(field), mode, newValue, field, tail(path));
         }
+
         return new Value(hash);
     }
 
-    private Value insertInto(final Value value, final InsertMode mode, final Value newValue, final String field,
-            final String[] tail) {
+    private Value insertInto(final Value value, final InsertMode mode, final Value newValue, final String field, final String[] tail) {
         if (value != null) {
             final FixPath fixPath = new FixPath(tail);
             newValue.withPathSet(value.getPath());
@@ -320,10 +324,12 @@ import java.util.Map;
     // TODO replace switch, extract to method on array?
     private Value getReferencedValue(final Array array, final String field, final String p) {
         Value referencedValue = null;
+
         if (Value.isNumber(field)) {
             final int index = Integer.valueOf(field) - 1;
             return 0 <= index && index < array.size() ? array.get(index) : null;
         }
+
         final ReservedField reservedField = ReservedField.fromString(field);
         if (reservedField != null) {
             switch (reservedField) {
@@ -341,6 +347,7 @@ import java.util.Map;
                     break;
             }
         }
+
         return referencedValue;
     }
 

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -127,8 +127,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
             @Override
             public void literal(final String name, final String value) {
                 final String[] split = Value.split(name);
-                addValue(split[split.length - 1], new Value(value, name));
-                // TODO could this help with https://github.com/metafacture/metafacture-fix/issues/147?
+                addValue(split[split.length - 1], new Value(value));
                 // TODO use full path here to insert only once?
                 // new FixPath(name).insertInto(currentRecord, InsertMode.APPEND, new Value(value));
             }
@@ -236,9 +235,10 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
         }
         else {
             final Value entity = entities.get(index);
+            value.withPathSet(entity.getPath());
             entity.matchType()
-                .ifArray(a -> a.add(value.updatePathAddBase(entity, name)))
-                .ifHash(h -> h.add(name, value.updatePathAddBase(entity, name)))
+                .ifArray(a -> a.add(value))
+                .ifHash(h -> h.add(name, value))
                 .orElseThrow();
         }
     }

--- a/metafix/src/main/java/org/metafacture/metafix/Record.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Record.java
@@ -209,9 +209,7 @@ public class Record extends Value.Hash {
                     toDelete.addFirst(insertPath);
                 }
                 else {
-                    final Value newValue = new Value(newString);
-                    insertPath.insertInto(this, InsertMode.REPLACE, newValue);
-                    newValue.setPath(insertPath.toString());
+                    insertPath.insertInto(this, InsertMode.REPLACE, new Value(newString));
                 }
             }
             toDelete.forEach(path -> path.removeNestedFrom(this));

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -100,17 +100,12 @@ public class Value {
         }
     }
 
-    public Value(final String string) {
-        this(string, null);
-    }
-
     public Value(final int integer) {
         this(String.valueOf(integer));
     }
 
-    public Value(final String string, final String path) {
+    public Value(final String string) {
         this(string != null ? Type.String : null, null, null, string);
-        this.path = path;
     }
 
     public static Value newArray() {
@@ -204,35 +199,6 @@ public class Value {
         }
     }
 
-    /*package-private*/ Value updatePathRename(final String newName) {
-        if (path != null) {
-            path = FixPath.RESERVED_FIELD_PATTERN.matcher(newName).replaceAll(Matcher.quoteReplacement(split(path)[0]));
-        }
-
-        return this;
-    }
-
-    /*package-private*/ Value updatePathAddBase(final Value container, final String fallback) {
-        if (container.path != null) {
-            final String[] pathSegments = split(path != null ? path : fallback);
-            final String lastSegment = pathSegments[pathSegments.length - 1];
-            this.path = container.path + "." + lastSegment;
-        }
-
-        return this;
-    }
-
-    /*package-private*/ Value updatePathAppend(final String suffix, final String fallback) {
-        if (path != null) {
-            path = path + suffix;
-        }
-        else {
-            path = fallback + suffix;
-        }
-
-        return this;
-    }
-
     public TypeMatcher matchType() {
         return new TypeMatcher(this);
     }
@@ -286,8 +252,22 @@ public class Value {
         return path;
     }
 
-    /*package-private*/ void setPath(final String path) {
-        this.path = path;
+    /*package-private*/ Value withPathSet(final String p) {
+        this.path = p;
+        return this;
+    }
+
+    /*package-private*/ Value withPathAppend(final int i) {
+        return withPathAppend(String.valueOf(i));
+    }
+
+    /*package-private*/ Value withPathAppend(final String field) {
+        if (path == null || path.isEmpty()) {
+            return this.withPathSet(field);
+        }
+        else {
+            return this.withPathSet(path + "." + field);
+        }
     }
 
     /*package-private*/ Value copy() {
@@ -395,8 +375,12 @@ public class Value {
         }
 
         public void add(final Value value) {
+            add(value, true);
+        }
+
+        public void add(final Value value, final boolean appendToPath) {
             if (!isNull(value)) {
-                list.add(value);
+                list.add(appendToPath ? value.withPathAppend(list.size() + 1) : value);
             }
         }
 
@@ -454,6 +438,7 @@ public class Value {
 
         /*package-private*/ void set(final int index, final Value value) {
             list.set(index, value);
+            value.withPathAppend(index + 1);
         }
 
         /*package-private*/ void removeIf(final Predicate<Value> predicate) {
@@ -549,8 +534,12 @@ public class Value {
          * @param value the metadata value
          */
         public void put(final String field, final Value value) {
+            put(field, value, true);
+        }
+
+        /*package-private*/ void put(final String field, final Value value, final boolean appendToPath) {
             if (!isNull(value)) {
-                map.put(field, value);
+                map.put(field, appendToPath ? value.withPathAppend(field) : value);
             }
         }
 
@@ -583,8 +572,8 @@ public class Value {
 
             return set.isEmpty() ? null : set.size() == 1 ? getField(set.iterator().next(), enforceStringValue) :
                 newArray(a -> set.forEach(f -> getField(f, enforceStringValue).matchType()
-                            .ifArray(b -> b.forEach(a::add))
-                            .orElse(a::add)
+                            .ifArray(b -> b.forEach(t -> a.add(t, false)))
+                            .orElse(t -> a.add(t, false))
                 ));
         }
 
@@ -628,15 +617,13 @@ public class Value {
                 put(field, newValue);
             }
             else {
+                final String basePath = oldValue.getPath();
                 if (!oldValue.isArray()) { // repeated field: convert single val to first in array
-                    oldValue.updatePathAppend(".1", field);
+                    oldValue.withPathAppend(1);
                 }
 
-                put(field, oldValue.asList(oldVals -> newValue.asList(newVals -> {
-                    for (int i = 0; i < newVals.size(); ++i) {
-                        oldVals.add(newVals.get(i).updatePathAppend("." + (i + 1 + oldVals.size()), field));
-                    }
-                })));
+                put(field, oldValue.asList(oldVals -> newValue
+                        .asList(newVals -> newVals.forEach(newVal -> oldVals.add(newVal.withPathSet(basePath))))));
             }
         }
 

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -100,12 +100,12 @@ public class Value {
         }
     }
 
-    public Value(final int integer) {
-        this(String.valueOf(integer));
-    }
-
     public Value(final String string) {
         this(string != null ? Type.String : null, null, null, string);
+    }
+
+    public Value(final int integer) {
+        this(String.valueOf(integer));
     }
 
     public static Value newArray() {
@@ -257,17 +257,12 @@ public class Value {
         return this;
     }
 
-    /*package-private*/ Value withPathAppend(final int i) {
+    private Value withPathAppend(final int i) {
         return withPathAppend(String.valueOf(i));
     }
 
-    /*package-private*/ Value withPathAppend(final String field) {
-        if (path == null || path.isEmpty()) {
-            return this.withPathSet(field);
-        }
-        else {
-            return this.withPathSet(path + "." + field);
-        }
+    private Value withPathAppend(final String field) {
+        return withPathSet(path == null || path.isEmpty() ? field : path + "." + field);
     }
 
     /*package-private*/ Value copy() {
@@ -437,8 +432,7 @@ public class Value {
         }
 
         /*package-private*/ void set(final int index, final Value value) {
-            list.set(index, value);
-            value.withPathAppend(index + 1);
+            list.set(index, value.withPathAppend(index + 1));
         }
 
         /*package-private*/ void removeIf(final Predicate<Value> predicate) {
@@ -622,8 +616,8 @@ public class Value {
                     oldValue.withPathAppend(1);
                 }
 
-                put(field, oldValue.asList(oldVals -> newValue
-                        .asList(newVals -> newVals.forEach(newVal -> oldVals.add(newVal.withPathSet(basePath))))));
+                put(field, oldValue.asList(oldVals -> newValue.asList(newVals ->
+                                newVals.forEach(newVal -> oldVals.add(newVal.withPathSet(basePath))))));
             }
         }
 

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -373,7 +373,7 @@ public class Value {
             add(value, true);
         }
 
-        public void add(final Value value, final boolean appendToPath) {
+        /* package-private */ void add(final Value value, final boolean appendToPath) {
             if (!isNull(value)) {
                 list.add(appendToPath ? value.withPathAppend(list.size() + 1) : value);
             }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
  * @author Fabian Steeg
  */
 @ExtendWith(MockitoExtension.class)
-@ExtendWith(MetafixToDo.Extension.class)
 public class MetafixLookupTest {
 
     private static final String CSV_MAP = "src/test/resources/org/metafacture/metafix/maps/test.csv";
@@ -789,7 +788,6 @@ public class MetafixLookupTest {
     }
 
     @Test
-    @MetafixToDo("See https://github.com/hbz/lobid-resources/pull/1354")
     public void shouldLookupInCopiedNestedArrays() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "put_map('rswk-indicator', s: 'SubjectHeading')",
@@ -819,22 +817,10 @@ public class MetafixLookupTest {
                 o.get().startEntity("1");
                 o.get().startEntity("type[]");
                 o.get().literal("1", "SubjectHeading");
-                f.apply(2).endEntity();
-                o.get().startEntity("2");
-                o.get().startEntity("type[]");
-                o.get().literal("1", "SubjectHeading");
-                f.apply(2).endEntity();
-                o.get().startEntity("3");
-                o.get().startEntity("type[]");
-                o.get().literal("1", "SubjectHeading");
-                f.apply(2).endEntity();
-                o.get().startEntity("4");
-                o.get().startEntity("type[]");
-                o.get().literal("1", "SubjectHeading");
-                f.apply(2).endEntity();
-                o.get().startEntity("5");
-                o.get().startEntity("type[]");
-                o.get().literal("1", "SubjectHeading");
+                o.get().literal("2", "SubjectHeading");
+                o.get().literal("3", "SubjectHeading");
+                o.get().literal("4", "SubjectHeading");
+                o.get().literal("5", "SubjectHeading");
                 f.apply(5).endEntity();
                 o.get().endRecord();
             }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -1964,7 +1964,7 @@ public class MetafixMethodTest {
     @Test
     // We currently fail on unresolved references, see MetafixRecordTests#assertThrowsOnEmptyArray
     public void addFieldIntoArrayOfObjectsWithLastWildcardMissingError() {
-        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Using ref, but can't find: $last in: null", () -> {
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Can't find: $last in: null", () -> {
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "add_field('animals[].$last.key', 'value')"
                 ),

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1113,7 +1113,7 @@ public class MetafixRecordTest {
     }
 
     private void assertThrowsOnEmptyArray(final String index) {
-        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Using ref, but can't find: " + index + " in: null", () -> {
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Can't find: " + index + " in: null", () -> {
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "add_field('animals[]." + index + ".kind','nice')"
                 ),

--- a/metafix/src/test/java/org/metafacture/metafix/RecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/RecordTest.java
@@ -350,8 +350,8 @@ public class RecordTest {
             }));
             a.add(Value.newHash(h -> {
                 h.put(FIELD, VALUE);
-                // For proper transformation, we need to explicitly set the path (as in Metafix.java):
-                h.put(OTHER_FIELD, new Value(OTHER_VALUE.asString(), String.format(path, a.size() + 1)));
+                // For proper transformation, we have to explicitly set the path (as in Metafix.java):
+                h.put(OTHER_FIELD, OTHER_VALUE.withPathSet(String.format(path, a.size() + 1)), false);
             }));
         }));
 

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/expected.json
@@ -1,51 +1,51 @@
 {
   "subject" : [ {
+    "type" : [ "ComplexSubject" ],
     "componentList" : [ {
-      "gndIdentifier" : "(DE-588)4131620-4",
-      "id" : "(DE-588)4131620-4",
+      "type" : [ "SubjectHeading" ],
       "label" : "Schulhof",
       "source" : {
-        "id" : "https://d-nb.info/gnd/7749153-1",
-        "label" : "Gemeinsame Normdatei (GND)"
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
       },
-      "type" : [ "SubjectHeading" ]
+      "id" : "(DE-588)4131620-4",
+      "gndIdentifier" : "(DE-588)4131620-4"
     }, {
-      "gndIdentifier" : "(DE-588)4116546-9",
-      "id" : "(DE-588)4116546-9",
+      "type" : [ "SubjectHeading" ],
       "label" : "Sozialraum",
       "source" : {
-        "id" : "https://d-nb.info/gnd/7749153-1",
-        "label" : "Gemeinsame Normdatei (GND)"
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
       },
-      "type" : [ "SubjectHeading" ]
+      "id" : "(DE-588)4116546-9",
+      "gndIdentifier" : "(DE-588)4116546-9"
     }, {
-      "gndIdentifier" : "(DE-588)4680202-2",
-      "id" : "(DE-588)4680202-2",
+      "type" : [ "SubjectHeading" ],
       "label" : "Informelles Lernen",
       "source" : {
-        "id" : "https://d-nb.info/gnd/7749153-1",
-        "label" : "Gemeinsame Normdatei (GND)"
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
       },
-      "type" : [ "SubjectHeading" ]
+      "id" : "(DE-588)4680202-2",
+      "gndIdentifier" : "(DE-588)4680202-2"
     }, {
-      "gndIdentifier" : "(DE-588)4155947-2",
-      "id" : "(DE-588)4155947-2",
+      "type" : [ "SubjectHeading" ],
       "label" : "Ganztagsschule",
       "source" : {
-        "id" : "https://d-nb.info/gnd/7749153-1",
-        "label" : "Gemeinsame Normdatei (GND)"
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
       },
-      "type" : [ "SubjectHeading" ]
+      "id" : "(DE-588)4155947-2",
+      "gndIdentifier" : "(DE-588)4155947-2"
     }, {
-      "gndIdentifier" : "(DE-588)4130615-6",
-      "id" : "(DE-588)4130615-6",
+      "type" : [ "SubjectHeading" ],
       "label" : "Sportpädagogik",
       "source" : {
-        "id" : "https://d-nb.info/gnd/7749153-1",
-        "label" : "Gemeinsame Normdatei (GND)"
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
       },
-      "type" : [ "SubjectHeading" ]
-    } ],
-    "type" : [ "ComplexSubject" ]
+      "id" : "(DE-588)4130615-6",
+      "gndIdentifier" : "(DE-588)4130615-6"
+    } ]
   } ]
 }

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/expected.json
@@ -46,7 +46,6 @@
       },
       "type" : [ "SubjectHeading" ]
     } ],
-    "label" : [ ],
     "type" : [ "ComplexSubject" ]
   } ]
 }

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/test.fix
@@ -3,25 +3,24 @@ put_map("rswk-indicator", s: "SubjectHeading")
 set_array("subject[]")
 
 if exists("6890?")
-  set_array("subject[].$append.type[]", "ComplexSubject")
-  set_array("subject[].$last.label")
-  set_array("subject[].$last.componentList[]")
+  set_array("subject[].$append.componentList[]")
   do list(path: "6890?", "var": "$i")
-    set_array("subject[].$last.componentList[].$append.type[]")
-    do list(path: "$i.D", "var": "$k")
-      copy_field("$k", "subject[].$last.componentList[].$last.type[].$append")
-    end
-    copy_field("$i.a", "subject[].$last.componentList[].$last.label")
     do list(path: "$i.0", "var": "$j")
       if any_match("$j", "^\\(DE-588\\)(.*)$")
-        add_field("subject[].$last.componentList[].$last.source.label", "Gemeinsame Normdatei (GND)")
-        add_field("subject[].$last.componentList[].$last.source.id", "https://d-nb.info/gnd/7749153-1")
+        copy_field("$j", "subject[].$last.componentList[].$append.gndIdentifier")
         copy_field("$j", "subject[].$last.componentList[].$last.id")
+        copy_field("$i.a", "subject[].$last.componentList[].$last.label")
+        add_field("subject[].$last.componentList[].$last.source.id", "https://d-nb.info/gnd/7749153-1")
+        add_field("subject[].$last.componentList[].$last.source.label", "Gemeinsame Normdatei (GND)")
         replace_all("subject[].$last.componentList[].$last..id", "^\\(DE-588\\)(.*)$", "http://d-nb.info/gnd/$1")
-        copy_field("$j", "subject[].$last.componentList[].$last.gndIdentifier")
         replace_all("subject[].$last.componentList[].$last..gndIdentifier", "^\\(DE-588\\)(.*)$", "$1")
       end
     end
+    set_array("subject[].$last.componentList[].$last.type[]")
+    do list(path: "$i.D", "var": "$k")
+      copy_field("$k", "subject[].$last.componentList[].$last.type[].$append")
+    end
+    set_array("subject[].$last.type[]", "ComplexSubject")
   end
 end
 

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/test.fix
@@ -3,24 +3,25 @@ put_map("rswk-indicator", s: "SubjectHeading")
 set_array("subject[]")
 
 if exists("6890?")
-  set_array("subject[].$append.componentList[]")
+  set_array("subject[].$append.type[]", "ComplexSubject")
+  set_array("subject[].$last.label")
+  set_array("subject[].$last.componentList[]")
   do list(path: "6890?", "var": "$i")
-    do list(path: "$i.0", "var": "$j")
-      if any_match("$j", "^\\(DE-588\\)(.*)$")
-        copy_field("$j", "subject[].$last.componentList[].$append.gndIdentifier")
-        copy_field("$j", "subject[].$last.componentList[].$last.id")
-        copy_field("$i.a", "subject[].$last.componentList[].$last.label")
-        add_field("subject[].$last.componentList[].$last.source.id", "https://d-nb.info/gnd/7749153-1")
-        add_field("subject[].$last.componentList[].$last.source.label", "Gemeinsame Normdatei (GND)")
-        replace_all("subject[].$last.componentList[].$last..id", "^\\(DE-588\\)(.*)$", "http://d-nb.info/gnd/$1")
-        replace_all("subject[].$last.componentList[].$last..gndIdentifier", "^\\(DE-588\\)(.*)$", "$1")
-      end
-    end
-    set_array("subject[].$last.componentList[].$last.type[]")
+    set_array("subject[].$last.componentList[].$append.type[]")
     do list(path: "$i.D", "var": "$k")
       copy_field("$k", "subject[].$last.componentList[].$last.type[].$append")
     end
-    set_array("subject[].$last.type[]", "ComplexSubject")
+    copy_field("$i.a", "subject[].$last.componentList[].$last.label")
+    do list(path: "$i.0", "var": "$j")
+      if any_match("$j", "^\\(DE-588\\)(.*)$")
+        add_field("subject[].$last.componentList[].$last.source.label", "Gemeinsame Normdatei (GND)")
+        add_field("subject[].$last.componentList[].$last.source.id", "https://d-nb.info/gnd/7749153-1")
+        copy_field("$j", "subject[].$last.componentList[].$last.id")
+        replace_all("subject[].$last.componentList[].$last..id", "^\\(DE-588\\)(.*)$", "http://d-nb.info/gnd/$1")
+        copy_field("$j", "subject[].$last.componentList[].$last.gndIdentifier")
+        replace_all("subject[].$last.componentList[].$last..gndIdentifier", "^\\(DE-588\\)(.*)$", "$1")
+      end
+    end
   end
 end
 

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/lookup/fromXml/toJson/lookupInDeeplyNestedArrayOfObjects/todo.txt
@@ -1,1 +1,0 @@
-See hbz/lobid-resources#1354


### PR DESCRIPTION
Append to path when adding values, set base path for nested values.

This seems to resolves the issue in hbz/lobid-resources#1354, see unit and integration tests, which are now passing, but tweaked (unit test for output structure, integration test for field order).