### PR TITLE
Add `from_json()`/`to_json()` Fix functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,18 @@ Flattens a nested array field.
 flatten("<sourceField>")
 ```
 
+##### `from_json`
+
+Replaces the string with its JSON deserialization.
+
+Options:
+
+- `error_string`: Error message as a placeholder if the JSON couldn't be parsed. (Default: `null`)
+
+```perl
+from_json("<sourceField>"[, error_string: "<errorValue>"])
+```
+
 ##### `index`
 
 Returns the index position of a substring in a field and replaces the field value with this number.
@@ -513,7 +525,7 @@ Options:
 
 - `to`: ISBN format to convert to (either `ISBN10` or `ISBN13`). (Default: Only normalize ISBN)
 - `verify_check_digit`: Whether the check digit should be verified. (Default: `false`)
-- `error_string`: Error message as a placeholder if the ISBN couln't be validated. (Default: `null`)
+- `error_string`: Error message as a placeholder if the ISBN couldn't be validated. (Default: `null`)
 
 ```perl
 isbn("<sourceField>"[, to: "<isbnFormat>"][, verify_check_digit: "<boolean>"][, error_string: "<errorValue>"])
@@ -593,6 +605,19 @@ Sums numbers in an array and replaces the field value with this number.
 
 ```perl
 sum("<sourceField>")
+```
+
+##### `to_json`
+
+Replaces the value with its JSON serialization.
+
+Options:
+
+- `error_string`: Error message as a placeholder if the JSON couldn't be generated. (Default: `null`)
+- `pretty`: Whether to use pretty printing. (Default: `false`)
+
+```perl
+to_json("<sourceField>"[, pretty: "<boolean>"][, error_string: "<errorValue>"])
 ```
 
 ##### `trim`

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -10,10 +10,11 @@ def passSystemProperties = {
 }
 
 dependencies {
-  implementation "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
-  implementation "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
   implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
   implementation "com.google.guava:guava:${versions.guava}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
+  implementation "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
   implementation "org.slf4j:slf4j-api:${versions.slf4j}"
 
   testImplementation "org.junit.jupiter:junit-jupiter-api:${versions.junit_jupiter}"

--- a/metafix/src/main/java/org/metafacture/metafix/JsonValue.java
+++ b/metafix/src/main/java/org/metafacture/metafix/JsonValue.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 hbz NRW
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.metafacture.metafix;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+
+// TODO: Utilize JsonDecoder/JsonEncoder instead?
+
+@FunctionalInterface
+public interface JsonValue {
+
+    void toJson(JsonGenerator jsonGenerator);
+
+    default String toJson() throws IOException {
+        return toJson(false);
+    }
+
+    default String toJson(final boolean prettyPrinting) throws IOException {
+        final StringWriter writer = new StringWriter();
+        final JsonGenerator jsonGenerator = new JsonFactory().createGenerator(writer);
+        jsonGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
+
+        try {
+            toJson(jsonGenerator);
+        }
+        catch (final UncheckedIOException e) {
+            throw e.getCause();
+        }
+
+        jsonGenerator.flush();
+
+        return writer.toString();
+    }
+
+    class Parser {
+
+        private static final ObjectMapper MAPPER = new ObjectMapper();
+
+        public Parser() {
+        }
+
+        public Value parse(final String source) throws IOException {
+            return parse(MAPPER.readTree(source));
+        }
+
+        private Value parse(final JsonNode node) {
+            final Value value;
+
+            if (node.isObject()) {
+                value = Value.newHash(h -> node.fields().forEachRemaining(e -> h.put(e.getKey(), parse(e.getValue()))));
+            }
+            else if (node.isArray()) {
+                value = Value.newArray(a -> node.elements().forEachRemaining(v -> a.add(parse(v))));
+            }
+            else {
+                value = new Value(node.textValue());
+            }
+
+            return value;
+        }
+
+    }
+
+}

--- a/metafix/src/main/java/org/metafacture/metafix/Record.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Record.java
@@ -19,14 +19,6 @@ package org.metafacture.metafix;
 import org.metafacture.metafix.FixPath.InsertMode;
 import org.metafacture.metafix.Value.TypeMatcher;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.SerializableString;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedHashMap;
@@ -116,27 +108,6 @@ public class Record extends Value.Hash {
     public String toString() {
         // TODO: Improve string representation? Include reject status, virtual fields, etc.?
         return super.toString();
-    }
-
-    public String toJson() throws IOException {
-        return toJson(false);
-    }
-
-    public String toJson(final boolean prettyPrinting) throws IOException {
-        final StringWriter writer = new StringWriter();
-        final JsonGenerator jsonGenerator = new JsonFactory().createGenerator(writer);
-        jsonGenerator.setPrettyPrinter(prettyPrinting ? new DefaultPrettyPrinter((SerializableString) null) : null);
-
-        try {
-            toJson(jsonGenerator);
-        }
-        catch (final UncheckedIOException e) {
-            throw e.getCause();
-        }
-
-        jsonGenerator.flush();
-
-        return writer.toString();
     }
 
     /**

--- a/metafix/src/main/java/org/metafacture/metafix/Value.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Value.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
  * Represents a record value, i.e., either an {@link Array}, a {@link Hash},
  * or a {@link String}.
  */
-public class Value { // checkstyle-disable-line ClassDataAbstractionCoupling
+public class Value implements JsonValue { // checkstyle-disable-line ClassDataAbstractionCoupling
 
     private static final String FIELD_PATH_SEPARATOR = "\\.";
 
@@ -248,7 +248,8 @@ public class Value { // checkstyle-disable-line ClassDataAbstractionCoupling
         );
     }
 
-    private void toJson(final JsonGenerator jsonGenerator) {
+    @Override
+    public void toJson(final JsonGenerator jsonGenerator) {
         if (isNull()) {
             try {
                 jsonGenerator.writeNull();
@@ -357,7 +358,7 @@ public class Value { // checkstyle-disable-line ClassDataAbstractionCoupling
 
     }
 
-    private abstract static class AbstractValueType {
+    private abstract static class AbstractValueType implements JsonValue {
 
         protected static final Predicate<Value> REMOVE_EMPTY_VALUES = v ->
             v.extractType((m, c) -> m
@@ -383,7 +384,8 @@ public class Value { // checkstyle-disable-line ClassDataAbstractionCoupling
         @Override
         public abstract String toString();
 
-        protected abstract void toJson(JsonGenerator jsonGenerator);
+        @Override
+        public abstract void toJson(JsonGenerator jsonGenerator);
 
     }
 
@@ -459,7 +461,7 @@ public class Value { // checkstyle-disable-line ClassDataAbstractionCoupling
         }
 
         @Override
-        protected void toJson(final JsonGenerator jsonGenerator) {
+        public void toJson(final JsonGenerator jsonGenerator) {
             try {
                 jsonGenerator.writeStartArray();
                 forEach(v -> v.toJson(jsonGenerator));
@@ -737,7 +739,7 @@ public class Value { // checkstyle-disable-line ClassDataAbstractionCoupling
         }
 
         @Override
-        protected void toJson(final JsonGenerator jsonGenerator) {
+        public void toJson(final JsonGenerator jsonGenerator) {
             try {
                 jsonGenerator.writeStartObject();
 

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.metafacture.metafix;
+package org.metafacture.metafix; // checkstyle-disable-line JavaNCSS
 
 import org.metafacture.framework.StreamReceiver;
 
@@ -1077,6 +1077,155 @@ public class MetafixMethodTest {
                 o.get().startRecord("1");
                 o.get().literal("animals", "Lion");
                 o.get().literal("animals", "Tiger");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertNullFromJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "from_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "null");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "null");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertStringFromJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "from_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "\"eeny meeny miny moe\"");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "eeny meeny miny moe");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertArrayFromJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "from_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "[\"eeny\",\"meeny\",\"miny\",\"moe\"]");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "eeny");
+                o.get().literal("test", "meeny");
+                o.get().literal("test", "miny");
+                o.get().literal("test", "moe");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertHashFromJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "from_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "{\"a\":[\"eeny\",\"meeny\"],\"b\":\"miny\",\"c\":{\"d\":\"moe\"}}");
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("test");
+                o.get().literal("a", "eeny");
+                o.get().literal("a", "meeny");
+                o.get().literal("b", "miny");
+                o.get().startEntity("c");
+                o.get().literal("d", "moe");
+                f.apply(2).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertHashFromPrettyJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "from_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test",
+                        "{\n" +
+                        "  \"a\" : [ \"eeny\", \"meeny\" ],\n" +
+                        "  \"b\" : \"miny\",\n" +
+                        "  \"c\" : {\n" +
+                        "    \"d\" : \"moe\"\n" +
+                        "  }\n" +
+                        "}"
+                );
+                i.endRecord();
+            },
+            (o, f) -> {
+                o.get().startRecord("1");
+                o.get().startEntity("test");
+                o.get().literal("a", "eeny");
+                o.get().literal("a", "meeny");
+                o.get().literal("b", "miny");
+                o.get().startEntity("c");
+                o.get().literal("d", "moe");
+                f.apply(2).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldNotConvertInvalidObjectFromJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "from_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "eeny meeny miny moe");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "eeny meeny miny moe");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertInvalidObjectFromJsonWithErrorString() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "from_json(test, error_string: 'invalid')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "eeny meeny miny moe");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "invalid");
                 o.get().endRecord();
             }
         );
@@ -3118,6 +3267,103 @@ public class MetafixMethodTest {
                 o.get().startEntity("dumbers[]");
                 o.get().literal("1", "20");
                 f.apply(3).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertStringToJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "to_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "eeny meeny miny moe");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "\"eeny meeny miny moe\"");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertArrayToJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "to_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("test", "eeny");
+                i.literal("test", "meeny");
+                i.literal("test", "miny");
+                i.literal("test", "moe");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "[\"eeny\",\"meeny\",\"miny\",\"moe\"]");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertHashToJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "to_json(test)"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("test");
+                i.literal("a", "eeny");
+                i.literal("a", "meeny");
+                i.literal("b", "miny");
+                i.startEntity("c");
+                i.literal("d", "moe");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test", "{\"a\":[\"eeny\",\"meeny\"],\"b\":\"miny\",\"c\":{\"d\":\"moe\"}}");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldConvertHashToPrettyJson() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "to_json(test, pretty: 'true')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("test");
+                i.literal("a", "eeny");
+                i.literal("a", "meeny");
+                i.literal("b", "miny");
+                i.startEntity("c");
+                i.literal("d", "moe");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("test",
+                        "{\n" +
+                        "  \"a\" : [ \"eeny\", \"meeny\" ],\n" +
+                        "  \"b\" : \"miny\",\n" +
+                        "  \"c\" : {\n" +
+                        "    \"d\" : \"moe\"\n" +
+                        "  }\n" +
+                        "}"
+                );
                 o.get().endRecord();
             }
         );


### PR DESCRIPTION
Open questions:

1. `shouldConvertNullFromJson()` seems counterintuitive; but fixing it would require changing the behaviour of `Record.transform(String, BiConsumer)`. Also, we'd have to differentiate between value being `null` and `error_string` being `null`. One option might be to generate an empty string which could then get at least cleaned up by `vacuum()`.
2. `to_json()` error behaviour is untested; I have no idea how to conjure up an invalid object ;)
3. Should we somehow utilize JsonDecoder/JsonEncoder instead of interacting with Jackson directly? Would certainly allow for greater compatibility/configurability.

@TobiasNx: Do you also want to do a functional review?