### PR TITLE
Add `put_macro()`/`call_macro()` Fix bind and function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,25 @@ array("foo")
 # {"name":"value"} => ["name", "value"]
 ```
 
+##### `call_macro`
+
+Calls a named macro, i.e. a list of statements that have been previously defined with the [`do put_macro`](#do-put_macro) bind.
+
+Parameters:
+
+- `name` (required): Unique name of the macro.
+
+Options:
+
+- All options are made available as "dynamic" local variables in the macro.
+
+```perl
+do put_macro("<macroName>"[, <staticLocalVariables>...])
+  ...
+end
+call_macro("<macroName>"[, <dynamicLocalVariables>...])
+```
+
 ##### `copy_field`
 
 Copies (or appends to) a field from an existing field.
@@ -264,25 +283,6 @@ E.g.:
 ```perl
 hash("foo")
 # ["name", "value"] => {"name":"value"}
-```
-
-##### `macro`
-
-Calls a named macro, i.e. a list of statements that have been previously defined with the [`do macro`](#do-macro) bind.
-
-Parameters:
-
-- `name` (required): Unique name of the macro.
-
-Options:
-
-- All options are made available as "dynamic" local variables.
-
-```perl
-do macro("<macroName>"[, <staticLocalVariables>...])
-  ...
-end
-macro("<macroName>"[, <dynamicLocalVariables>...])
 ```
 
 ##### `move_field`
@@ -632,25 +632,6 @@ do list(path: "<sourceField>", "var": "<variableName>")
 end
 ```
 
-#### `do macro`
-
-Defines a named macro, i.e. a list of statements that can be executed later with the [`macro`](#macro) function.
-
-Parameters:
-
-- `name` (required): Unique name of the macro.
-
-Options:
-
-- All options are made available as "static" local variables.
-
-```perl
-do macro("<macroName>"[, <staticLocalVariables>...])
-  ...
-end
-macro("<macroName>"[, <dynamicLocalVariables>...])
-```
-
 #### `do once`
 
 Executes the statements only once (when the bind is first encountered), not repeatedly for each record.
@@ -670,6 +651,25 @@ end
 do once("vars setup")
   ...
 end
+```
+
+#### `do put_macro`
+
+Defines a named macro, i.e. a list of statements that can be executed later with the [`call_macro`](#call_macro) function.
+
+Parameters:
+
+- `name` (required): Unique name of the macro.
+
+Options:
+
+- All options are made available as "static" local variables in the macro.
+
+```perl
+do put_macro("<macroName>"[, <staticLocalVariables>...])
+  ...
+end
+call_macro("<macroName>"[, <dynamicLocalVariables>...])
 ```
 
 ### Conditionals

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ put_map("<mapName>",
 
 ##### `put_var`
 
-Defines a single internal variable that can be referenced with `$[<variableName>]`.
+Defines a single global variable that can be referenced with `$[<variableName>]`.
 
 ```perl
 put_var("<variableName>", "<variableValue>")
@@ -200,7 +200,7 @@ put_var("<variableName>", "<variableValue>")
 
 ##### `put_vars`
 
-Defines multiple internal variables that can be referenced with `$[<variableName>]`.
+Defines multiple global variables that can be referenced with `$[<variableName>]`.
 
 ```perl
 put_vars(
@@ -264,6 +264,25 @@ E.g.:
 ```perl
 hash("foo")
 # ["name", "value"] => {"name":"value"}
+```
+
+##### `macro`
+
+Calls a named macro, i.e. a list of statements that have been previously defined with the [`do macro`](#do-macro) bind.
+
+Parameters:
+
+- `name` (required): Unique name of the macro.
+
+Options:
+
+- All options are made available as "dynamic" local variables.
+
+```perl
+do macro("<macroName>"[, <staticLocalVariables>...])
+  ...
+end
+macro("<macroName>"[, <dynamicLocalVariables>...])
 ```
 
 ##### `move_field`
@@ -611,6 +630,25 @@ When specifying a variable name for the current element, the record remains acce
 do list(path: "<sourceField>", "var": "<variableName>")
   ...
 end
+```
+
+#### `do macro`
+
+Defines a named macro, i.e. a list of statements that can be executed later with the [`macro`](#macro) function.
+
+Parameters:
+
+- `name` (required): Unique name of the macro.
+
+Options:
+
+- All options are made available as "static" local variables.
+
+```perl
+do macro("<macroName>"[, <staticLocalVariables>...])
+  ...
+end
+macro("<macroName>"[, <dynamicLocalVariables>...])
 ```
 
 #### `do once`

--- a/README.md
+++ b/README.md
@@ -657,6 +657,12 @@ end
 
 Defines a named macro, i.e. a list of statements that can be executed later with the [`call_macro`](#call_macro) function.
 
+Variables can be referenced with `$[<variableName>]`, in the following order of precedence:
+
+1. "dynamic" local variables, passed as options to the `call_macro` function;
+2. "static" local variables, passed as options to the `do put_macro` bind;
+3. global variables, defined via [`put_var`](#put_var)/[`put_vars`](#put_vars).
+
 Parameters:
 
 - `name` (required): Unique name of the macro.

--- a/metafix/src/main/java/org/metafacture/metafix/FixBind.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixBind.java
@@ -60,8 +60,16 @@ public enum FixBind implements FixContext {
         }
     },
 
+    macro {
+        @Override
+        public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {
+            recordTransformer.addVars(options);
+            metafix.putMacro(params.get(0), recordTransformer);
+        }
+    },
+
     once {
-        private Map<Metafix, Set<String>> executed = new HashMap<>();
+        private final Map<Metafix, Set<String>> executed = new HashMap<>();
 
         @Override
         public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {

--- a/metafix/src/main/java/org/metafacture/metafix/FixBind.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixBind.java
@@ -60,14 +60,6 @@ public enum FixBind implements FixContext {
         }
     },
 
-    macro {
-        @Override
-        public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {
-            recordTransformer.addVars(options);
-            metafix.putMacro(params.get(0), recordTransformer);
-        }
-    },
-
     once {
         private final Map<Metafix, Set<String>> executed = new HashMap<>();
 
@@ -76,6 +68,14 @@ public enum FixBind implements FixContext {
             if (executed.computeIfAbsent(metafix, k -> new HashSet<>()).add(params.isEmpty() ? null : params.get(0))) {
                 recordTransformer.transform(record);
             }
+        }
+    },
+
+    put_macro {
+        @Override
+        public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {
+            recordTransformer.addVars(options);
+            metafix.putMacro(params.get(0), recordTransformer);
         }
     }
 

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -120,6 +120,20 @@ public enum FixMethod implements FixFunction {
             })));
         }
     },
+    call_macro {
+        @Override
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final String macroName = params.get(0);
+            final RecordTransformer recordTransformer = metafix.getMacro(macroName);
+
+            if (recordTransformer != null) {
+                recordTransformer.transform(record, options);
+            }
+            else {
+                throw new IllegalArgumentException("Macro '" + macroName + "' undefined!");
+            }
+        }
+    },
     copy_field {
         @Override
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
@@ -151,18 +165,6 @@ public enum FixMethod implements FixFunction {
                     h.put(a.get(i - 1).asString(), a.get(i));
                 }
             })));
-        }
-    },
-    macro {
-        @Override
-        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-            final RecordTransformer recordTransformer = metafix.getMacro(params.get(0));
-            if (recordTransformer != null) {
-                recordTransformer.transform(record, options);
-            }
-            else {
-                // TODO?: Metamorph throws MorphBuildException("Macro '" + macroName + "' undefined!")
-            }
         }
     },
     move_field {

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -153,6 +153,18 @@ public enum FixMethod implements FixFunction {
             })));
         }
     },
+    macro {
+        @Override
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            final RecordTransformer recordTransformer = metafix.getMacro(params.get(0));
+            if (recordTransformer != null) {
+                recordTransformer.transform(record, options);
+            }
+            else {
+                // TODO?: Metamorph throws MorphBuildException("Macro '" + macroName + "' undefined!")
+            }
+        }
+    },
     move_field {
         @Override
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -72,8 +72,9 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
     private final Deque<Integer> entityCountStack = new LinkedList<>();
     private final List<Closeable> resources = new ArrayList<>();
     private final List<Expression> expressions = new ArrayList<>();
-    private final Map<String, RecordTransformer> fixCache = new HashMap<>();
     private final Map<String, Map<String, String>> maps = new HashMap<>();
+    private final Map<String, RecordTransformer> fixCache = new HashMap<>();
+    private final Map<String, RecordTransformer> macros = new HashMap<>();
     private final Map<String, String> vars = new HashMap<>();
     private final RecordTransformer recordTransformer;
     private final StreamFlattener flattener = new StreamFlattener();
@@ -161,6 +162,14 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
 
     private RecordTransformer getRecordTransformer(final Reader fixDef) {
         return new RecordTransformer(this, FixStandaloneSetup.parseFix(fixDef));
+    }
+
+    public void putMacro(final String name, final RecordTransformer macro) {
+        macros.put(name, macro);
+    }
+
+    public RecordTransformer getMacro(final String name) {
+        return macros.get(name);
     }
 
     public List<Expression> getExpressions() {

--- a/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
+++ b/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
@@ -63,20 +63,22 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
     private final List<Consumer<Record>> consumers = new LinkedList<>();
     private final List<Map<String, String>> vars = new ArrayList<>();
     private final Metafix metafix;
+    private final RecordTransformer parent;
 
     private Supplier<String> currentMessageSupplier;
 
     /*package-private*/ RecordTransformer(final Metafix metafix, final Fix fix) {
-        this(metafix, fix.getElements());
+        this(metafix, fix.getElements(), null);
+        addVars(metafix.getVars());
     }
 
-    private RecordTransformer(final Metafix metafix, final List<Expression> expressions) {
+    private RecordTransformer(final Metafix metafix, final List<Expression> expressions, final RecordTransformer parent) {
         this.metafix = metafix;
-        addVars(metafix.getVars());
+        this.parent = parent;
 
         expressions.forEach(e -> {
-            final Params params = new Params(e.getParams(), vars);
-            final Options options = new Options(e.getOptions(), vars);
+            final Params params = new Params(e.getParams(), this);
+            final Options options = new Options(e.getOptions(), this);
 
             if (e instanceof Do) {
                 processDo((Do) e, params, options);
@@ -94,6 +96,10 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
                 throw new FixProcessException(executionExceptionMessage(e));
             }
         });
+    }
+
+    private RecordTransformer childTransformer(final List<Expression> expressions) {
+        return new RecordTransformer(metafix, expressions, this);
     }
 
     public void addVars(final Map<String, String> additionalVars) {
@@ -125,7 +131,7 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
     private void processDo(final Do expression, final Params params, final Options options) {
         processFix(() -> executionExceptionMessage(expression), () -> {
             final FixContext context = getInstance(expression.getName(), FixContext.class, FixBind::valueOf);
-            final RecordTransformer recordTransformer = new RecordTransformer(metafix, expression.getElements());
+            final RecordTransformer recordTransformer = childTransformer(expression.getElements());
 
             return record -> context.execute(metafix, record, params.resolve(), options.resolve(), recordTransformer);
         });
@@ -140,14 +146,14 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
 
         processFix(() -> executionExceptionMessage(ifExpression, ifExpression.eResource()), () -> {
             final FixPredicate ifPredicate = getInstance(ifExpression.getName(), FixPredicate.class, FixConditional::valueOf);
-            final RecordTransformer ifTransformer = new RecordTransformer(metafix, ifExpression.getElements());
+            final RecordTransformer ifTransformer = childTransformer(ifExpression.getElements());
 
             final List<FixPredicate> elseIfPredicates = mapList(elseIfExpressions, e -> getInstance(e.getName(), FixPredicate.class, FixConditional::valueOf));
-            final List<Params> elseIfParamsList = mapList(elseIfExpressions, e -> new Params(e.getParams(), vars));
-            final List<Options> elseIfOptionsList = mapList(elseIfExpressions, e -> new Options(e.getOptions(), vars));
-            final List<RecordTransformer> elseIfTransformers = mapList(elseIfExpressions, e -> new RecordTransformer(metafix, e.getElements()));
+            final List<Params> elseIfParamsList = mapList(elseIfExpressions, e -> new Params(e.getParams(), this));
+            final List<Options> elseIfOptionsList = mapList(elseIfExpressions, e -> new Options(e.getOptions(), this));
+            final List<RecordTransformer> elseIfTransformers = mapList(elseIfExpressions, e -> childTransformer(e.getElements()));
 
-            final RecordTransformer elseTransformer = elseExpression != null ? new RecordTransformer(metafix, elseExpression.getElements()) : null;
+            final RecordTransformer elseTransformer = elseExpression != null ? childTransformer(elseExpression.getElements()) : null;
 
             return record -> {
                 if (ifPredicate.test(metafix, record, ifParams.resolve(), ifOptions.resolve())) {
@@ -182,7 +188,7 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
     private void processUnless(final Unless expression, final Params params, final Options options) {
         processFix(() -> executionExceptionMessage(expression, expression.eResource()), () -> {
             final FixPredicate predicate = getInstance(expression.getName(), FixPredicate.class, FixConditional::valueOf);
-            final RecordTransformer recordTransformer = new RecordTransformer(metafix, expression.getElements());
+            final RecordTransformer recordTransformer = childTransformer(expression.getElements());
 
             return record -> {
                 if (!predicate.test(metafix, record, params.resolve(), options.resolve())) {
@@ -255,6 +261,12 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
                 resource.getURI(), node.getStartLine(), NodeModelUtils.getTokenText(node));
     }
 
+    private Map<String, String> getVars() {
+        final Map<String, String> mergedVars = parent != null ? parent.getVars() : new HashMap<>();
+        vars.forEach(mergedVars::putAll);
+        return mergedVars;
+    }
+
     private abstract static class AbstractResolvable<T> {
 
         protected boolean isResolvable(final String value) {
@@ -265,12 +277,6 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
             return value == null ? null : StringUtil.format(value, Metafix.VAR_START, Metafix.VAR_END, false, vars);
         }
 
-        protected Map<String, String> mergeVars(final List<Map<String, String>> vars) {
-            final Map<String, String> mergedVars = new HashMap<>();
-            vars.forEach(mergedVars::putAll);
-            return mergedVars;
-        }
-
         protected abstract T resolve();
 
     }
@@ -278,12 +284,12 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
     private static class Params extends AbstractResolvable<List<String>> {
 
         private final List<String> list;
-        private final List<Map<String, String>> vars;
+        private final RecordTransformer recordTransformer;
         private final boolean resolve;
 
-        private Params(final List<String> list, final List<Map<String, String>> vars) {
+        private Params(final List<String> list, final RecordTransformer recordTransformer) {
             this.list = list;
-            this.vars = vars;
+            this.recordTransformer = recordTransformer;
 
             resolve = list.stream().anyMatch(this::isResolvable);
         }
@@ -292,10 +298,10 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
         protected List<String> resolve() {
             if (resolve) {
                 final List<String> resolvedList = new ArrayList<>(list.size());
-                final Map<String, String> mergedVars = mergeVars(vars);
+                final Map<String, String> vars = recordTransformer.getVars();
 
                 for (final String entry : list) {
-                    resolvedList.add(resolveVars(entry, mergedVars));
+                    resolvedList.add(resolveVars(entry, vars));
                 }
 
                 return resolvedList;
@@ -310,11 +316,11 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
     private static class Options extends AbstractResolvable<Map<String, String>> {
 
         private final Map<String, String> map = new LinkedHashMap<>();
-        private final List<Map<String, String>> vars;
+        private final RecordTransformer recordTransformer;
         private final boolean resolve;
 
-        private Options(final org.metafacture.metafix.fix.Options options, final List<Map<String, String>> vars) {
-            this.vars = vars;
+        private Options(final org.metafacture.metafix.fix.Options options, final RecordTransformer recordTransformer) {
+            this.recordTransformer = recordTransformer;
 
             boolean resolveTemp = false;
 
@@ -341,10 +347,10 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
         protected Map<String, String> resolve() {
             if (resolve) {
                 final Map<String, String> resolvedMap = new LinkedHashMap<>(map.size());
-                final Map<String, String> mergedVars = mergeVars(vars);
+                final Map<String, String> vars = recordTransformer.getVars();
 
                 for (final Map.Entry<String, String> entry : map.entrySet()) {
-                    resolvedMap.put(resolveVars(entry.getKey(), mergedVars), resolveVars(entry.getValue(), mergedVars));
+                    resolvedMap.put(resolveVars(entry.getKey(), vars), resolveVars(entry.getValue(), vars));
                 }
 
                 return resolvedMap;

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -1992,11 +1992,11 @@ public class MetafixRecordTest {
     @Test
     public void shouldCallMacro() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "do macro('test')",
+                "do put_macro('test')",
                 "  add_field('test', '42')",
                 "end",
-                "macro('test')",
-                "macro('test')"
+                "call_macro('test')",
+                "call_macro('test')"
             ),
             i -> {
                 i.startRecord("1");
@@ -2012,18 +2012,18 @@ public class MetafixRecordTest {
 
     @Test
     public void shouldNotCallUnknownMacro() {
-        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "macro('test')",
-                "macro('test')"
-            ),
-            i -> {
-                i.startRecord("1");
-                i.endRecord();
-            },
-            o -> {
-                o.get().startRecord("1");
-                o.get().endRecord();
-            }
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Macro 'test' undefined!", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "call_macro('test')",
+                    "call_macro('test')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
         );
     }
 
@@ -2031,11 +2031,11 @@ public class MetafixRecordTest {
     public void shouldCallMacroWithVariables() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "put_vars(a: '1', b: '2')", // global variables
-                "do macro('test', b: '22', c: '33')", // "static" local variables
+                "do put_macro('test', b: '22', c: '33')", // "static" local variables
                 "  add_field('test', '$[a]-$[b]-$[c]-$[d]')",
                 "end",
-                "macro('test', c: '333', d: '444')", // "dynamic" local variables
-                "macro('test', b: '555', d: '666')",
+                "call_macro('test', c: '333', d: '444')", // "dynamic" local variables
+                "call_macro('test', b: '555', d: '666')",
                 "add_field('vars', '$[a]-$[b]')"
             ),
             i -> {
@@ -2056,13 +2056,13 @@ public class MetafixRecordTest {
     public void shouldCallMacroWithVariablesPassedToNestedBinds() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "put_vars(a: '1', b: '2')", // global variables
-                "do macro('test', b: '22', c: '33')", // "static" local variables
+                "do put_macro('test', b: '22', c: '33')", // "static" local variables
                 "  do once()",
                 "    add_field('test', '$[a]-$[b]-$[c]-$[d]')",
                 "  end",
                 "end",
-                "macro('test', c: '333', d: '444')", // "dynamic" local variables
-                "macro('test', b: '555', d: '666')",
+                "call_macro('test', c: '333', d: '444')", // "dynamic" local variables
+                "call_macro('test', b: '555', d: '666')",
                 "add_field('vars', '$[a]-$[b]')"
             ),
             i -> {
@@ -2082,13 +2082,13 @@ public class MetafixRecordTest {
     public void shouldCallMacroWithVariablesPassedToNestedConditionals() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "put_vars(a: '1', b: '2')", // global variables
-                "do macro('test', b: '22', c: '33')", // "static" local variables
+                "do put_macro('test', b: '22', c: '33')", // "static" local variables
                 "  if any_equal('cond', '$[d]')",
                 "    add_field('test', '$[a]-$[b]-$[c]-$[d]')",
                 "  end",
                 "end",
-                "macro('test', c: '333', d: '444')", // "dynamic" local variables
-                "macro('test', b: '555', d: '666')",
+                "call_macro('test', c: '333', d: '444')", // "dynamic" local variables
+                "call_macro('test', b: '555', d: '666')",
                 "add_field('vars', '$[a]-$[b]')"
             ),
             i -> {
@@ -2111,10 +2111,10 @@ public class MetafixRecordTest {
         MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Variable 'c' was not assigned!\nAssigned variables:\n{a=1, b=2}", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "put_vars(a: '1', b: '2')", // global variables
-                    "do macro('test', b: '22', c: '33')", // "static" local variables
+                    "do put_macro('test', b: '22', c: '33')", // "static" local variables
                     "end",
-                    "macro('test', c: '333', d: '444')", // "dynamic" local variables
-                    "macro('test', b: '555', d: '666')",
+                    "call_macro('test', c: '333', d: '444')", // "dynamic" local variables
+                    "call_macro('test', b: '555', d: '666')",
                     "add_field('test', '$[a]-$[b]-$[c]-$[d]')"
                 ),
                 i -> {
@@ -2130,15 +2130,15 @@ public class MetafixRecordTest {
     @Test
     public void shouldCallNestedMacro() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "do macro('test1', c: '23')",
+                "do put_macro('test1', c: '23')",
                 "  add_field('test$[a]', '42')",
-                "  macro('test2', b: '$[b]', c: '$[c]')",
+                "  call_macro('test2', b: '$[b]', c: '$[c]')",
                 "end",
-                "do macro('test2')",
+                "do put_macro('test2')",
                 "  add_field('test$[b]', '$[c]')",
                 "end",
-                "macro('test1', a: '1', b: '2')",
-                "macro('test1', a: '3', b: '4')"
+                "call_macro('test1', a: '1', b: '2')",
+                "call_macro('test1', a: '3', b: '4')"
             ),
             i -> {
                 i.startRecord("1");


### PR DESCRIPTION
Ports Metamorph [macros](https://github.com/metafacture/metafacture-core/wiki/Metamorph-User-Guide#defining-macros) to Metafix.

Open questions:

- Should the function be named `call_macro()` instead?
- Should calling an unknown macro throw an exception?