### PR TITLE
Add `flatten()` Fix function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,14 @@ Only keeps field values that match the regular expression pattern.
 filter("<sourceField>", "<regexp>")
 ```
 
+##### `flatten`
+
+Flattens a nested array field.
+
+```perl
+flatten("<sourceField>")
+```
+
 ##### `index`
 
 Returns the index position of a substring in a field and replaces the field value with this number.

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -389,6 +389,14 @@ public enum FixMethod implements FixFunction {
             );
         }
     },
+    flatten {
+        @Override
+        public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            record.transform(params.get(0), (m, c) -> m
+                    .ifArray(a -> c.accept(newArray(flatten(a.stream()))))
+            );
+        }
+    },
     index {
         @Override
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixFunction.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixFunction.java
@@ -55,4 +55,11 @@ public interface FixFunction {
         return stream.filter(set::add);
     }
 
+    default Stream<Value> flatten(final Stream<Value> stream) {
+        return stream.flatMap(v -> v.extractType((m, c) -> m
+                    .ifArray(a -> c.accept(flatten(a.stream())))
+                    .orElse(w -> c.accept(Stream.of(w)))
+        ));
+    }
+
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -1110,6 +1110,156 @@ public class MetafixMethodTest {
     }
 
     @Test
+    public void shouldFlattenFlatArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "flatten('flat')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("flat", "1");
+                i.literal("flat", "2");
+                i.literal("flat", "3");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("flat", "1");
+                o.get().literal("flat", "2");
+                o.get().literal("flat", "3");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldFlattenFlatHash() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "flatten('flat')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("flat");
+                i.literal("a", "1");
+                i.literal("a", "2");
+                i.literal("a", "3");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("flat");
+                o.get().literal("a", "1");
+                o.get().literal("a", "2");
+                o.get().literal("a", "3");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldFlattenFlatString() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "flatten('flat')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("flat", "1");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("flat", "1");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldFlattenNestedArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "flatten('deep[]')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("deep[]");
+                i.literal("1", "1");
+                i.startEntity("2[]");
+                i.literal("1", "2");
+                i.literal("2", "3");
+                i.endEntity();
+                i.startEntity("3[]");
+                i.startEntity("1[]");
+                i.literal("1", "4");
+                i.literal("2", "5");
+                i.endEntity();
+                i.literal("2", "6");
+                i.endEntity();
+                i.literal("4", "7");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("deep[]");
+                o.get().literal("1", "1");
+                o.get().literal("2", "2");
+                o.get().literal("3", "3");
+                o.get().literal("4", "4");
+                o.get().literal("5", "5");
+                o.get().literal("6", "6");
+                o.get().literal("7", "7");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldFlattenNestedArrayWithHashes() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "flatten('deep[]')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("deep[]");
+                i.literal("1", "1");
+                i.startEntity("2");
+                i.literal("a", "2");
+                i.literal("a", "3");
+                i.endEntity();
+                i.startEntity("3[]");
+                i.startEntity("1");
+                i.literal("a", "4");
+                i.literal("a", "5");
+                i.endEntity();
+                i.literal("2", "6");
+                i.endEntity();
+                i.literal("4", "7");
+                i.endEntity();
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("deep[]");
+                o.get().literal("1", "1");
+                o.get().startEntity("2");
+                o.get().literal("a", "2");
+                o.get().literal("a", "3");
+                o.get().endEntity();
+                o.get().startEntity("3");
+                o.get().literal("a", "4");
+                o.get().literal("a", "5");
+                o.get().endEntity();
+                o.get().literal("4", "6");
+                o.get().literal("5", "7");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
     public void shouldGetFirstIndexOfSubstring() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "index(animal, 'n')"

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flatten/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flatten/todo.txt
@@ -1,1 +1,0 @@
-See issue #122

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/expected.json
@@ -1,0 +1,5 @@
+{
+  "zoo" : [ {
+    "animals" : [ "ant", "dog", "cat", "fish", "zebra", "horse", "hippo", "giraffe" ]
+  } ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/input.json
@@ -1,0 +1,3 @@
+{
+  "zoo": [ {"animals" : [ [ "ant", "dog" ], "cat", [ "fish", [ "zebra", "horse" ], "hippo" ], "giraffe"] } ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/test.fix
@@ -1,0 +1,1 @@
+flatten("zoo.*.animals[]")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/test.fix
@@ -1,1 +1,1 @@
-flatten("zoo.*.animals[]")
+flatten("zoo[].*.animals[]")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromJson/toJson/flattenNested/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-records
+|decode-json
+|fix(FLUX_DIR + "test.fix")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;


### PR DESCRIPTION
Implements Catmandu's [`flatten()`](https://metacpan.org/pod/Catmandu::Fix::flatten) function.

Resolves #122.