### PR TITLE
Add `str_contain()`/`str_equal()`/`str_match()` Fix conditionals.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixConditional.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixConditional.java
@@ -41,6 +41,12 @@ public enum FixConditional implements FixPredicate {
             return !any_contain.test(metafix, record, params, options);
         }
     },
+    str_contain {
+        @Override
+        public boolean test(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            return testConditional(params, CONTAINS);
+        }
+    },
 
     all_equal {
         @Override
@@ -58,6 +64,12 @@ public enum FixConditional implements FixPredicate {
         @Override
         public boolean test(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             return !any_equal.test(metafix, record, params, options);
+        }
+    },
+    str_equal {
+        @Override
+        public boolean test(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            return testConditional(params, EQUALS);
         }
     },
 
@@ -112,6 +124,12 @@ public enum FixConditional implements FixPredicate {
         @Override
         public boolean test(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             return !any_match.test(metafix, record, params, options);
+        }
+    },
+    str_match {
+        @Override
+        public boolean test(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
+            return testConditional(params, MATCHES);
         }
     }
 

--- a/metafix/src/main/java/org/metafacture/metafix/api/FixPredicate.java
+++ b/metafix/src/main/java/org/metafacture/metafix/api/FixPredicate.java
@@ -49,4 +49,8 @@ public interface FixPredicate {
         ));
     }
 
+    default boolean testConditional(final List<String> params, final BiPredicate<String, String> conditional) {
+        return conditional.test(params.get(0), params.get(1));
+    }
+
 }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -1430,4 +1430,179 @@ public class MetafixIfTest {
         );
     }
 
+    @Test
+    public void shouldContainString() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "if str_contain('name', 'a$[var]')",
+                "  add_field('type', 'Organization')",
+                "end"
+            ),
+            ImmutableMap.of("var", "me"),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Mame");
+                i.literal("name", "A University");
+                i.endRecord();
+
+                i.startRecord("2");
+                i.literal("name", "Mame");
+                i.literal("name", "Max");
+                i.endRecord();
+
+                i.startRecord("3");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "A University");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+
+                o.get().startRecord("2");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "Max");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+
+                o.get().startRecord("3");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldEqualString() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "if str_equal('name', 'na$[var]')",
+                "  add_field('type', 'Organization')",
+                "end"
+            ),
+            ImmutableMap.of("var", "me"),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Mame");
+                i.literal("name", "A University");
+                i.endRecord();
+
+                i.startRecord("2");
+                i.literal("name", "Mame");
+                i.literal("name", "Max");
+                i.endRecord();
+
+                i.startRecord("3");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "A University");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+
+                o.get().startRecord("2");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "Max");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+
+                o.get().startRecord("3");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldMatchString() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "if str_match('name', '.*a$[var]')",
+                "  add_field('type', 'Organization')",
+                "end"
+            ),
+            ImmutableMap.of("var", "me"),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Mame");
+                i.literal("name", "A University");
+                i.endRecord();
+
+                i.startRecord("2");
+                i.literal("name", "Mame");
+                i.literal("name", "Max");
+                i.endRecord();
+
+                i.startRecord("3");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "A University");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+
+                o.get().startRecord("2");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "Max");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+
+                o.get().startRecord("3");
+                o.get().literal("type", "Organization");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldTestMacroVariable() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "do macro('test')",
+                "  if str_contain('name', 'a$[var]')",
+                "    add_field('type', 'Organization: $[var]')",
+                "  end",
+                "end",
+                "macro('test', 'var': 'm')",
+                "macro('test', 'var': 'me')",
+                "macro('test', 'var': 'mee')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", "Mame");
+                i.literal("name", "A University");
+                i.endRecord();
+
+                i.startRecord("2");
+                i.literal("name", "Mame");
+                i.literal("name", "Max");
+                i.endRecord();
+
+                i.startRecord("3");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "A University");
+                o.get().literal("type", "Organization: m");
+                o.get().literal("type", "Organization: me");
+                o.get().endRecord();
+
+                o.get().startRecord("2");
+                o.get().literal("name", "Mame");
+                o.get().literal("name", "Max");
+                o.get().literal("type", "Organization: m");
+                o.get().literal("type", "Organization: me");
+                o.get().endRecord();
+
+                o.get().startRecord("3");
+                o.get().literal("type", "Organization: m");
+                o.get().literal("type", "Organization: me");
+                o.get().endRecord();
+            }
+        );
+    }
+
 }


### PR DESCRIPTION
Complements path/string (`any_*()`) and path/path (`in()`) conditionals with string/string variants.

Particular useful in combination with local variables in `macro()` (#243) or `include()` (#245).

_Base branch will be changed automatically once #243 is merged._