### PR TITLE
Optionally apply "strict" mode to `FixProcessException`s.

### DIFF
--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/expected.json
@@ -1,0 +1,7 @@
+{
+  "contribution" : [ {
+    "agent" : {
+      "label" : "COLEMAN, Julie"
+    }
+  } ]
+}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/input.xml
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/input.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+    <record>
+        <datafield tag="700" ind1="1" ind2=" ">
+            <subfield code="a">COLEMAN, Julie</subfield>
+            <subfield code="e">Editor</subfield>
+            <subfield code="a">KAY, Christian J.</subfield>
+            <subfield code="e">NS</subfield>
+        </datafield>
+    </record>
+</collection>

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/test.fix
@@ -1,0 +1,9 @@
+set_array("contribution[]")
+
+do list(path: "700[01] ", "var": "$i")
+  set_hash("contribution[].$append.agent")
+  copy_field("$i.a", "contribution[].$last.agent.label")
+end
+
+replace_all("contribution[].*.agent.label", "(?<!\\p{Upper})\\.$|[,]$", "")
+retain("contribution[]")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/method/fromXml/toJson/replace_toUpperStrictnessHandlesProcessExceptions/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.xml"
+|open-file
+|decode-xml
+|handle-marcxml
+|fix(FLUX_DIR + "test.fix", strictness="expression", strictnessHandlesProcessExceptions="true")
+|encode-json(prettyPrinting="true")
+|write(FLUX_DIR + "output-metafix.json")
+;


### PR DESCRIPTION
Allows to subject `FixProcessException`s to the same treatment as `FixExecutionException`s.

I.e., when `strictness` is set and `strictnessHandlesProcessExceptions` is not, it only handles `FixExecutionException`s; when `strictnessHandlesProcessExceptions` is set _in addition_ to `strictness`, it handles `FixExecutionException`s _and_ `FixProcessException`s.

Related to #251.