### PR TITLE
Fix macro performance regression.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixBind.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixBind.java
@@ -74,7 +74,7 @@ public enum FixBind implements FixContext {
     put_macro {
         @Override
         public void execute(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options, final RecordTransformer recordTransformer) {
-            recordTransformer.addVars(options);
+            recordTransformer.setVars(options);
             metafix.putMacro(params.get(0), recordTransformer);
         }
     }


### PR DESCRIPTION
Every time a macro is (re-)declared (e.g., for each record), its "static" local variables (options) are added to an internal list. So this list grows with each record and merging it (`RecordTransformer.getVars()`) takes longer and longer.

Instead, keep track of each type of variables (global, static, dynamic) separately and replace already existing variables of the same type.

Resolves #258.