### PR TITLE
Include caller location and text in macro execution exception.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -171,7 +171,13 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
     }
 
     public RecordTransformer getMacro(final String name) {
-        return macros.get(name);
+        final RecordTransformer macro = macros.get(name);
+
+        if (macro != null) {
+            macro.setParentExceptionMessage(recordTransformer);
+        }
+
+        return macro;
     }
 
     public List<Expression> getExpressions() {

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -174,7 +174,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
         final RecordTransformer macro = macros.get(name);
 
         if (macro != null) {
-            macro.setParentExceptionMessage(recordTransformer);
+            macro.setParentExceptionMessageFrom(recordTransformer);
         }
 
         return macro;

--- a/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
+++ b/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
@@ -272,7 +272,7 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
         return sb.toString();
     }
 
-    /*package-private*/ void setParentExceptionMessage(final RecordTransformer parentTransformer) {
+    /*package-private*/ void setParentExceptionMessageFrom(final RecordTransformer parentTransformer) {
         parentExceptionMessage = parentTransformer != null && parentTransformer.currentMessageSupplier != null ?
             parentTransformer.currentMessageSupplier.get() : null;
     }

--- a/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
+++ b/metafix/src/main/java/org/metafacture/metafix/RecordTransformer.java
@@ -67,6 +67,7 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
     private final Metafix metafix;
     private final RecordTransformer parent;
 
+    private String parentExceptionMessage;
     private Supplier<String> currentMessageSupplier;
 
     private enum Vars {
@@ -242,10 +243,10 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
             return e; // TODO: Add nesting information?
         }
         catch (final IllegalStateException | NumberFormatException e) {
-            return new FixExecutionException(currentMessageSupplier.get(), e);
+            return new FixExecutionException(getCurrentExceptionMessage(), e);
         }
         catch (final RuntimeException e) { // checkstyle-disable-line IllegalCatch
-            final MetafactureException exception = new FixProcessException(currentMessageSupplier.get(), e);
+            final MetafactureException exception = new FixProcessException(getCurrentExceptionMessage(), e);
 
             if (metafix.getStrictnessHandlesProcessExceptions()) {
                 return exception;
@@ -256,6 +257,24 @@ public class RecordTransformer { // checkstyle-disable-line ClassFanOutComplexit
         }
 
         return null;
+    }
+
+    private String getCurrentExceptionMessage() {
+        final StringBuilder sb = new StringBuilder();
+
+        if (parentExceptionMessage != null) {
+            sb.append(parentExceptionMessage);
+            sb.append(" -> ");
+        }
+
+        sb.append(currentMessageSupplier.get());
+
+        return sb.toString();
+    }
+
+    /*package-private*/ void setParentExceptionMessage(final RecordTransformer parentTransformer) {
+        parentExceptionMessage = parentTransformer != null && parentTransformer.currentMessageSupplier != null ?
+            parentTransformer.currentMessageSupplier.get() : null;
     }
 
     private String executionExceptionMessage(final Expression expression) {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -2156,6 +2156,64 @@ public class MetafixRecordTest {
     }
 
     @Test
+    public void shouldIncludeCallerLocationAndTextForExceptionInMacro() {
+        final String format = "Error while executing Fix expression (at FILE, line %d): %s";
+
+        final String text1 = "call_macro('test')";
+        final String text2 = "append('animals', ' is cool')";
+        final String message = String.format(format, 4, text1) + " -> " + String.format(format, 2, text2);
+
+        MetafixTestHelpers.assertThrows(FixExecutionException.class, s -> s.replaceAll("file:/.+?\\.fix", "FILE"), message, () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "do put_macro('test')",
+                    text2,
+                    "end",
+                    text1
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("animals");
+                    i.literal("1", "dog");
+                    i.literal("2", "cat");
+                    i.literal("3", "zebra");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldIncludeCallerLocationAndTextForExceptionInIncludedMacro() {
+        final String format = "Error while executing Fix expression (at FILE, line %d): %s";
+
+        final String text1 = "call_macro('test')";
+        final String text2 = "append('animals', ' is cool')";
+        final String message = String.format(format, 2, text1) + " -> " + String.format(format, 2, text2);
+
+        MetafixTestHelpers.assertThrows(FixExecutionException.class, s -> s.replaceAll("file:/.+?\\.fix", "FILE"), message, () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "include('src/test/resources/org/metafacture/metafix/fixes/macro.fix')",
+                    text1
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.startEntity("animals");
+                    i.literal("1", "dog");
+                    i.literal("2", "cat");
+                    i.literal("3", "zebra");
+                    i.endEntity();
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
     public void reject() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "if exists('_metadata.error')",

--- a/metafix/src/test/resources/org/metafacture/metafix/fixes/macro.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/fixes/macro.fix
@@ -1,0 +1,3 @@
+do put_macro("test")
+  append('animals', ' is cool')
+end


### PR DESCRIPTION
When a statement inside a macro fails, it's hard to find the actual call site. Provide the caller location for easier debugging.

Open question:

- Should the introductory phrase (`Error while ...`) be included for every item in the stack? Or should we build the combined message differently?

Related to #123 and #243.