### PR TITLE
Make `Value.Hash.findFields()` thread-safe with thread-local variables.

### DIFF
--- a/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/HashValueTest.java
@@ -16,6 +16,8 @@
 
 package org.metafacture.metafix;
 
+import org.metafacture.commons.tries.SimpleRegexTrie;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,8 @@ public class HashValueTest {
     public void shouldSatisfyEqualsContract() {
         EqualsVerifier.forClass(Value.Hash.class)
             .withPrefabValues(Value.class, Value.newArray(), Value.newHash())
+            .withPrefabValues(SimpleRegexTrie.class, new SimpleRegexTrie<String>(), new SimpleRegexTrie<String>())
+            .withIgnoredFields("patternMatcher", "prefixCache", "trie", "trieCache")
             .verify();
     }
 


### PR DESCRIPTION
Data structures in `Value.Hash.findFields(String, Set<String>)` are not safe to use across multiple threads. Switch to thread-local variables instead.

Resolves #255.