### PR TITLE
Fix `NoSuchFieldError` in lobid-resources web app.

### DIFF
--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
   implementation "com.google.guava:guava:${versions.guava}"
+  implementation "org.eclipse.emf:org.eclipse.emf.ecore:${versions.xtext}" // Workaround for hbz/lobid-resources#1462
   implementation "org.eclipse.xtext:org.eclipse.xtext.xbase:${versions.xtext}"
   implementation "org.eclipse.xtext:org.eclipse.xtext:${versions.xtext}"
   implementation "org.slf4j:slf4j-api:${versions.slf4j}"


### PR DESCRIPTION
It appears that sbt resolves to a newer version (2.28.0) than Maven/Gradle (2.20.0), which might cause some confusion in Xtext EMF registration.

Resolves hbz/lobid-resources#1462.