### PR TITLE
Change `add_field()` Fix function to destructive behaviour for Catmandu compatibility.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -127,7 +127,7 @@ public enum FixMethod implements FixFunction { // checkstyle-disable-line ClassD
     add_field {
         @Override
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
-            record.addNested(params.get(0), new Value(params.get(1)));
+            record.set(params.get(0), new Value(params.get(1)));
         }
     },
     array { // array-from-hash

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -572,8 +572,9 @@ public class MetafixBindTest {
 
     private void shouldIterateOverList(final String path, final int expectedCount) {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('trace')",
                 "do list(path: '" + path + "', 'var': '$i')",
-                "  add_field('trace', 'true')",
+                "  add_field('trace.$append', 'true')",
                 "end",
                 "retain('trace')"
             ),
@@ -617,8 +618,9 @@ public class MetafixBindTest {
 
     private void shouldIterateOverListOfHashes(final String path, final int expectedCount) {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('trace')",
                 "do list(path: '" + path + "', 'var': '$i')",
-                "  add_field('trace', 'true')",
+                "  add_field('trace.$append', 'true')",
                 "end",
                 "retain('trace')"
             ),

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixIfTest.java
@@ -2416,9 +2416,10 @@ public class MetafixIfTest {
     @Test
     public void shouldTestMacroVariable() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('type')",
                 "do put_macro('test')",
                 "  if str_contain('name', 'a$[var]')",
-                "    add_field('type', 'Organization: $[var]')",
+                "    add_field('type.$append', 'Organization: $[var]')",
                 "  end",
                 "end",
                 "call_macro('test', 'var': 'm')",

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -239,6 +239,48 @@ public class MetafixRecordTest {
             o -> {
                 o.get().startRecord("1");
                 o.get().startEntity("my");
+                o.get().literal("name", "nicolas");
+                o.get().endEntity();
+                o.get().endRecord();
+
+                o.get().startRecord("2");
+                o.get().startEntity("my");
+                o.get().literal("name", "nicolas");
+                o.get().endEntity();
+                o.get().endRecord();
+
+                o.get().startRecord("3");
+                o.get().startEntity("my");
+                o.get().literal("name", "nicolas");
+                o.get().endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void addWithAppendInNewArray() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('my.name')",
+                "add_field('my.name.$append','patrick')",
+                "add_field('my.name.$append','nicolas')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.endRecord();
+
+                i.startRecord("2");
+                i.startEntity("my");
+                i.literal("name", "max");
+                i.endEntity();
+                i.endRecord();
+
+                i.startRecord("3");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().startEntity("my");
                 o.get().literal("name", "patrick");
                 o.get().literal("name", "nicolas");
                 o.get().endEntity();
@@ -246,7 +288,6 @@ public class MetafixRecordTest {
 
                 o.get().startRecord("2");
                 o.get().startEntity("my");
-                o.get().literal("name", "max");
                 o.get().literal("name", "patrick");
                 o.get().literal("name", "nicolas");
                 o.get().endEntity();
@@ -1992,8 +2033,9 @@ public class MetafixRecordTest {
     @Test
     public void shouldCallMacro() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('test')",
                 "do put_macro('test')",
-                "  add_field('test', '42')",
+                "  add_field('test.$append', '42')",
                 "end",
                 "call_macro('test')",
                 "call_macro('test')"
@@ -2030,9 +2072,10 @@ public class MetafixRecordTest {
     @Test
     public void shouldCallMacroWithVariables() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('test')",
                 "put_vars(a: '1', b: '2')", // global variables
                 "do put_macro('test', b: '22', c: '33')", // "static" local variables
-                "  add_field('test', '$[a]-$[b]-$[c]-$[d]')",
+                "  add_field('test.$append', '$[a]-$[b]-$[c]-$[d]')",
                 "end",
                 "call_macro('test', c: '333', d: '444')", // "dynamic" local variables
                 "call_macro('test', b: '555', d: '666')",

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixScriptTest.java
@@ -202,9 +202,9 @@ public class MetafixScriptTest {
     public void shouldIncludeFixFile() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('trace')",
-                "add_field('trace', 'before include')",
+                "add_field('trace.$append', 'before include')",
                 "include('src/test/resources/org/metafacture/metafix/fixes/base.fix')",
-                "add_field('trace', 'after include')"
+                "add_field('trace.$append', 'after include')"
             ),
             i -> {
                 i.startRecord("1");
@@ -281,13 +281,13 @@ public class MetafixScriptTest {
     public void shouldIncludeFixFileInBind() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('trace')",
-                "add_field('trace', 'before bind')",
+                "add_field('trace.$append', 'before bind')",
                 "do list(path: 'data', 'var': '$i')",
                 "  paste('trace.$append', '~before include', '$i')",
                 "  include('src/test/resources/org/metafacture/metafix/fixes/var.fix')",
                 "  paste('trace.$append', '~after include', '$i')",
                 "end",
-                "add_field('trace', 'after bind')"
+                "add_field('trace.$append', 'after bind')"
             ),
             i -> {
                 i.startRecord("1");

--- a/metafix/src/test/resources/org/metafacture/metafix/fixes/include.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/fixes/include.fix
@@ -1,6 +1,6 @@
 unless exists("trace")
   set_array("trace")
 end
-add_field("trace", "before include")
+add_field("trace.$append", "before include")
 include("./base.fix")
-add_field("trace", "after include")
+add_field("trace.$append", "after include")

--- a/metafix/src/test/resources/org/metafacture/metafix/fixes/nested.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/fixes/nested.fix
@@ -1,4 +1,4 @@
 set_array("trace")
-add_field("trace", "before nested")
+add_field("trace.$append", "before nested")
 include("src/test/resources/org/metafacture/metafix/fixes/include.fix")
-add_field("trace", "after nested")
+add_field("trace.$append", "after nested")

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldSimpleDestructive/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/add_fieldSimpleDestructive/todo.txt
@@ -1,1 +1,0 @@
-See issue #116


### PR DESCRIPTION
Resolves (part of) #116.

NOTE: `add_field()` and `set_field()` are now equivalent, but according to [Catmandu's documentation](https://metacpan.org/pod/Catmandu::Fix::set_field) `set_field()` "will not create the intermediate structures if they are missing". (Opened #309 for this.)