### PR TITLE
Change `copy_field()`/`move_field()` Fix functions to destructive behaviour for Catmandu compatibility.

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -164,9 +164,16 @@ public enum FixMethod implements FixFunction { // checkstyle-disable-line ClassD
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final String oldName = params.get(0);
             final String newName = params.get(1);
-            Value.asList(record.get(oldName), a -> a.forEach(oldValue -> {
-                record.addNested(newName, oldValue); // we're actually aliasing
-            }));
+
+            final Value oldValue = record.get(oldName);
+            if (!Value.isNull(oldValue)) {
+                oldValue.matchType()
+                    .ifArray(a -> {
+                        record.remove(newName);
+                        a.forEach(v -> record.addNested(newName, v));
+                    })
+                    .orElse(v -> record.set(newName, v));
+            }
         }
     },
     format {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixBindTest.java
@@ -56,6 +56,28 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
+                o.get().literal("author", "MAX");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void doListExplicitAppend() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('author')",
+                "do list('path': 'name', 'var': 'n')",
+                " upcase('n')",
+                " trim('n')",
+                " copy_field('n', 'author.$append')",
+                "end",
+                "remove_field('name')"),
+            i -> {
+                i.startRecord("1");
+                i.literal("name", " A University");
+                i.literal("name", "Max ");
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
                 o.get().literal("author", "A UNIVERSITY");
                 o.get().literal("author", "MAX");
                 o.get().endRecord();
@@ -182,6 +204,30 @@ public class MetafixBindTest {
                 i.endRecord();
             }, o -> {
                 o.get().startRecord("1");
+                o.get().literal("author", "MAX");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void doListPathWithDotsExplicitAppend() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('author')",
+                "do list('path': 'some.name', 'var': 'n')",
+                " upcase('n')",
+                " trim('n')",
+                " copy_field('n', 'author.$append')",
+                "end",
+                "remove_field('some')"),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("some");
+                i.literal("name", " A University");
+                i.literal("name", "Max ");
+                i.endEntity();
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
                 o.get().literal("author", "A UNIVERSITY");
                 o.get().literal("author", "MAX");
                 o.get().endRecord();
@@ -228,6 +274,32 @@ public class MetafixBindTest {
                 " upcase('c.name')",
                 " trim('c.name')",
                 " copy_field('c.name', 'author')",
+                "end",
+                "remove_field('creator')"),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("creator");
+                i.literal("name", " A University");
+                i.endEntity();
+                i.startEntity("creator");
+                i.literal("name", "Max ");
+                i.endEntity();
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("author", "MAX");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void doListEntitesToLiteralsExplicitAppend() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('author')",
+                "do list('path': 'creator', 'var': 'c')",
+                " upcase('c.name')",
+                " trim('c.name')",
+                " copy_field('c.name', 'author.$append')",
                 "end",
                 "remove_field('creator')"),
             i -> {
@@ -388,6 +460,32 @@ public class MetafixBindTest {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "do list('path': 'name[]', 'var': 'n')",
                 " copy_field('n.name', 'author')",
+                "end",
+                "remove_field('name[]')"),
+            i -> {
+                i.startRecord("1");
+                i.startEntity("name[]");
+                i.startEntity("1");
+                i.literal("name", "A University");
+                i.endEntity();
+                i.startEntity("2");
+                i.literal("name", "Max");
+                i.endEntity();
+                i.endEntity();
+                i.endRecord();
+            }, o -> {
+                o.get().startRecord("1");
+                o.get().literal("author", "Max");
+                o.get().endRecord();
+            });
+    }
+
+    @Test
+    public void doListIndexedArrayOfObjectsExplicitAppend() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('author')",
+                "do list('path': 'name[]', 'var': 'n')",
+                " copy_field('n.name', 'author.$append')",
                 "end",
                 "remove_field('name[]')"),
             i -> {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixLookupTest.java
@@ -169,11 +169,30 @@ public class MetafixLookupTest {
     }
 
     @Test
-    public void shouldLookupCopiedInternalArrayWithAsterisk() {
+    public void shouldNotLookupCopiedInternalArrayWithAsterisk() {
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected Array or Hash, got String", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "set_array('data', 'Aloha')",
+                    "set_array('title')",
+                    "copy_field('data', 'title')",
+                    LOOKUP + " Aloha: Alohaeha)"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldLookupCopiedInternalArrayWithAsteriskExplicitAppend() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('data', 'Aloha')",
                 "set_array('title')",
-                "copy_field('data', 'title')",
+                "copy_field('data', 'title.$append')",
                 LOOKUP + " Aloha: Alohaeha)"
             ),
             i -> {
@@ -190,12 +209,32 @@ public class MetafixLookupTest {
     }
 
     @Test
-    public void shouldLookupCopiedDeduplicatedInternalArrayWithAsterisk() {
+    public void shouldNotLookupCopiedDeduplicatedInternalArrayWithAsterisk() {
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected Array or Hash, got String", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "set_array('data', 'Aloha', 'Aloha')",
+                    "uniq('data')",
+                    "set_array('title')",
+                    "copy_field('data', 'title')",
+                    LOOKUP + " Aloha: Alohaeha)"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldLookupCopiedDeduplicatedInternalArrayWithAsteriskExplicitAppend() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('data', 'Aloha', 'Aloha')",
                 "uniq('data')",
                 "set_array('title')",
-                "copy_field('data', 'title')",
+                "copy_field('data', 'title.$append')",
                 LOOKUP + " Aloha: Alohaeha)"
             ),
             i -> {
@@ -212,10 +251,10 @@ public class MetafixLookupTest {
     }
 
     @Test
-    public void shouldLookupCopiedExternalArrayWithAsterisk() {
+    public void shouldLookupCopiedExternalArrayWithAsteriskExplicitAppend() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('title')",
-                "copy_field('data', 'title')",
+                "copy_field('data', 'title.$append')",
                 LOOKUP + " Aloha: Alohaeha)"
             ),
             i -> {
@@ -233,11 +272,11 @@ public class MetafixLookupTest {
     }
 
     @Test
-    public void shouldLookupCopiedDeduplicatedExternalArrayWithAsterisk() {
+    public void shouldLookupCopiedDeduplicatedExternalArrayWithAsteriskExplicitAppend() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "uniq('data')",
                 "set_array('title')",
-                "copy_field('data', 'title')",
+                "copy_field('data', 'title.$append')",
                 LOOKUP + " Aloha: Alohaeha)"
             ),
             i -> {
@@ -256,11 +295,32 @@ public class MetafixLookupTest {
     }
 
     @Test
-    public void shouldLookupMovedDeduplicatedExternalArrayWithAsterisk() {
+    public void shouldNotLookupMovedDeduplicatedExternalArrayWithAsterisk() {
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected Array or Hash, got String", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "uniq('data')",
+                    "set_array('title')",
+                    "move_field('data', 'title')",
+                    LOOKUP + " Aloha: Alohaeha)"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("data", "Aloha");
+                    i.literal("data", "Aloha");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldLookupMovedDeduplicatedExternalArrayWithAsteriskExplicitAppend() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "uniq('data')",
                 "set_array('title')",
-                "move_field('data', 'title')",
+                "move_field('data', 'title.$append')",
                 LOOKUP + " Aloha: Alohaeha)"
             ),
             i -> {
@@ -278,10 +338,29 @@ public class MetafixLookupTest {
     }
 
     @Test
-    public void shouldLookupMovedExternalArrayWithAsterisk() {
+    public void shouldNotLookupMovedExternalArrayWithAsterisk() {
+        MetafixTestHelpers.assertExecutionException(IllegalStateException.class, "Expected Array or Hash, got String", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "set_array('title')",
+                    "move_field('data', 'title')",
+                    LOOKUP + " Aloha: Alohaeha)"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("data", "Aloha");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void shouldLookupMovedExternalArrayWithAsteriskExplicitAppend() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('title')",
-                "move_field('data', 'title')",
+                "move_field('data', 'title.$append')",
                 LOOKUP + " Aloha: Alohaeha)"
             ),
             i -> {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -2250,54 +2250,25 @@ public class MetafixMethodTest {
     }
 
     @Test
-    @MetafixToDo("Do we actually want implicit append? WDCD? See (passing) copyFieldToSubfieldOfArrayOfStringsWithIndexImplicitAppend")
     public void copyFieldToSubfieldOfArrayOfObjectsWithIndexImplicitAppend() {
-        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "set_array('test[]')",
-                "copy_field('key', 'test[].1.field')"
-            ),
-            i -> {
-                i.startRecord("1");
-                i.literal("key", "value");
-                i.endRecord();
-            },
-            (o, f) -> {
-                o.get().startRecord("1");
-                o.get().literal("key", "value");
-                o.get().startEntity("test[]");
-                o.get().startEntity("1");
-                o.get().literal("field", "value");
-                f.apply(2).endEntity();
-                o.get().endRecord();
-            }
+        MetafixTestHelpers.assertProcessException(IllegalArgumentException.class, "Can't find: 1 in: null", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "set_array('test[]')",
+                    "copy_field('key', 'test[].1.field')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("key", "value");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
         );
     }
 
     @Test
-    // Do we actually want implicit append? WDCD? See (failing) copyFieldToSubfieldOfArrayOfObjectsWithIndexImplicitAppend
-    public void copyFieldToSubfieldOfArrayOfStringsWithIndexImplicitAppend() {
-        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "set_array('test[]')",
-                "copy_field('key', 'test[].1')"
-            ),
-            i -> {
-                i.startRecord("1");
-                i.literal("key", "value");
-                i.endRecord();
-            },
-            o -> {
-                o.get().startRecord("1");
-                o.get().literal("key", "value");
-                o.get().startEntity("test[]");
-                o.get().literal("1", "value");
-                o.get().endEntity();
-                o.get().endRecord();
-            }
-        );
-    }
-
-    @Test
-    public void copyFieldToSubfieldOfArrayOfObjectsWithIndexExplicitAppend() {
+    public void copyFieldToSubfieldOfArrayOfObjectsWithExplicitAppend() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                 "set_array('test[]')",
                 "copy_field('key', 'test[].$append.field')"
@@ -2314,6 +2285,46 @@ public class MetafixMethodTest {
                 o.get().startEntity("1");
                 o.get().literal("field", "value");
                 f.apply(2).endEntity();
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void copyFieldToSubfieldOfArrayOfStringsWithIndexImplicitAppend() {
+        MetafixTestHelpers.assertProcessException(IndexOutOfBoundsException.class, "Index: 0, Size: 0", () ->
+            MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                    "set_array('test[]')",
+                    "copy_field('key', 'test[].1')"
+                ),
+                i -> {
+                    i.startRecord("1");
+                    i.literal("key", "value");
+                    i.endRecord();
+                },
+                o -> {
+                }
+            )
+        );
+    }
+
+    @Test
+    public void copyFieldToSubfieldOfArrayOfStringsWithExplicitAppend() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "set_array('test[]')",
+                "copy_field('key', 'test[].$append')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("key", "value");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("key", "value");
+                o.get().startEntity("test[]");
+                o.get().literal("1", "value");
+                o.get().endEntity();
                 o.get().endRecord();
             }
         );

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixRecordTest.java
@@ -569,9 +569,9 @@ public class MetafixRecordTest {
                 i.literal("cnimal", "zebra");
                 i.endRecord();
             },
-            (o, f) -> {
+            o -> {
                 o.get().startRecord("1");
-                f.apply(2).literal("animal", "dog");
+                o.get().literal("animal", "dog");
                 o.get().endRecord();
                 o.get().startRecord("2");
                 o.get().literal("bnimal", "cat");

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsIntoArrayOfObjectsWithAsteriskWildcard/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldArrayOfStringsIntoArrayOfObjectsWithAsteriskWildcard/todo.txt
@@ -1,0 +1,1 @@
+See issue #193

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldSimpleDestructive/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldSimpleDestructive/todo.txt
@@ -1,1 +1,0 @@
-See issue #116

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.err
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.err
@@ -1,0 +1,2 @@
+^Exception in thread "main" org\.metafacture\.metafix\.FixProcessException: Error while executing Fix expression \(at .*/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/test\.fix, line 2\): copy_field\("key", "test\[\]\.1"\)$
+^Caused by: java\.lang\.IndexOutOfBoundsException: Index: 0, Size: 0$

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.json
@@ -1,6 +1,0 @@
-{
-  "key" : "value",
-  "key_2" : "value_2",
-  "key_3" : "value_3",
-  "test" : [ "value", "value_2", "value_3" ]
-}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/move_fieldSimpleDestructive/todo.txt
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/move_fieldSimpleDestructive/todo.txt
@@ -1,1 +1,0 @@
-See issue #116


### PR DESCRIPTION
Resolves #116 (in combination with #308).

`move_field()` is implemented in terms of `copy_field()`, so changing the latter's behaviour also changes the former's.