### PR TITLE
Fix function "uri_encode" to be backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,9 +717,10 @@ Encodes a field value as URI. Aka percent-encoding.
 
 Options:
 
-- `allow_empty_values`: Sets whether to allow empty values in the filemap or to ignore these entries. (Default: `false`)
-- `compression`: Sets the compression of the file.
-
+- `plus_for_space`: Sets whether "space" (' ') will be substituted by a "plus" ('+') or be percent escaped ('%20'). Default: `true`)
+- `safe_chars`: Sets characters that won't be escaped. Safe characters are the
+ranges 0..9, a..z and A..Z. These are always safe and should not be specified.
+Default safe characters are also ".", "-", "*", and "_".
 
 ```perl
 uri_encode("<sourceField>"[, <options>...])

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ Encodes a field value as URI. Aka percent-encoding.
 
 Options:
 
-- `plus_for_space`: Sets whether "space" (' ') will be substituted by a "plus" ('+') or be percent escaped ('%20'). Default: `true`)
+- `plus_for_space`: Sets whether "space" (` `) will be substituted by a "plus" (`+`) or be percent escaped (`%20`). (Default: `true`)
 - `safe_chars`: Sets characters that won't be escaped. Safe characters are the
 ranges 0..9, a..z and A..Z. These are always safe and should not be specified.
 Default safe characters are also ".", "-", "*", and "_".

--- a/README.md
+++ b/README.md
@@ -718,9 +718,7 @@ Encodes a field value as URI. Aka percent-encoding.
 Options:
 
 - `plus_for_space`: Sets whether "space" (` `) will be substituted by a "plus" (`+`) or be percent escaped (`%20`). (Default: `true`)
-- `safe_chars`: Sets characters that won't be escaped. Safe characters are the
-ranges 0..9, a..z and A..Z. These are always safe and should not be specified.
-Default safe characters are also ".", "-", "*", and "_".
+- `safe_chars`: Sets characters that won't be escaped. Safe characters are the ranges 0..9, a..z and A..Z. These are always safe and should not be specified. (Default: `.-*_`)
 
 ```perl
 uri_encode("<sourceField>"[, <options>...])

--- a/README.md
+++ b/README.md
@@ -715,8 +715,20 @@ upcase("<sourceField>")
 
 Encodes a field value as URI. Aka percent-encoding.
 
+Options:
+
+- `allow_empty_values`: Sets whether to allow empty values in the filemap or to ignore these entries. (Default: `false`)
+- `compression`: Sets the compression of the file.
+
+
 ```perl
-uri_encode("<sourceField>")
+uri_encode("<sourceField>"[, <options>...])
+```
+
+E.g.:
+
+```perl
+uri_encode("path.to.field", plus_for_space:"false", safe_chars:"")
 ```
 
 ### Selectors

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
       'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.8.2',
       'junit_platform': '1.4.2',
-      'metafacture':    '5.7.0-rc1',
+      'metafacture':    '5.7.0-rc2',
       'mockito':        '2.27.0',
       'requirejs':      '2.3.6',
       'slf4j':          '1.7.21',

--- a/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FixMethod.java
@@ -668,7 +668,8 @@ public enum FixMethod implements FixFunction { // checkstyle-disable-line ClassD
         @Override
         public void apply(final Metafix metafix, final Record record, final List<String> params, final Map<String, String> options) {
             final URLEncode urlEncoder = new URLEncode();
-            urlEncoder.setPlusForSpace(false);
+            withOption(options, "safe_chars", urlEncoder::setSafeChars);
+            withOption(options, "plus_for_space", urlEncoder::setPlusForSpace, this::getBoolean);
 
             record.transform(params.get(0), urlEncoder::process);
         }

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -4047,7 +4047,7 @@ public class MetafixMethodTest {
     @Test
     public void shouldUriEncodePathSegmentWithoutSafeChars() {
         MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
-                "uri_encode('id', safe_chars:'', plus_for_space:'false')"
+                "uri_encode('id', safe_chars:'')"
             ),
             i -> {
                 i.startRecord("1");
@@ -4056,7 +4056,7 @@ public class MetafixMethodTest {
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().literal("id", "%2FDE%2DA96%3A%25%20%283%29%23%21");
+                o.get().literal("id", "%2FDE%2DA96%3A%25+%283%29%23%21");
                 o.get().endRecord();
             }
         );

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -4015,12 +4015,48 @@ public class MetafixMethodTest {
             ),
             i -> {
                 i.startRecord("1");
-                i.literal("id", "slash/990223521400206441:DE-A96:61 TYD 16(3)#!");
+                i.literal("id", "/DE-A96:% (3)#!");
                 i.endRecord();
             },
             o -> {
                 o.get().startRecord("1");
-                o.get().literal("id", "slash%2F990223521400206441%3ADE%2DA96%3A61%20TYD%2016%283%29%23%21");
+                o.get().literal("id", "%2FDE-A96%3A%25+%283%29%23%21");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldUriEncodePathSegmentWithoutPlusForSpace() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "uri_encode('id', plus_for_space:'false')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("id", "/DE-A96:% (3)#!");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("id", "%2FDE-A96%3A%25%20%283%29%23%21");
+                o.get().endRecord();
+            }
+        );
+    }
+
+    @Test
+    public void shouldUriEncodePathSegmentWithoutSafeChars() {
+        MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
+                "uri_encode('id', safe_chars:'', plus_for_space:'false')"
+            ),
+            i -> {
+                i.startRecord("1");
+                i.literal("id", "/DE-A96:% (3)#!");
+                i.endRecord();
+            },
+            o -> {
+                o.get().startRecord("1");
+                o.get().literal("id", "%2FDE%2DA96%3A%25%20%283%29%23%21");
                 o.get().endRecord();
             }
         );


### PR DESCRIPTION
See  metafacture/metafacture-fix#273.

- introduce options "safe_chars" and "plus_for_space" for function "uri_encode"
- update README
- bump metafacture dependency to 5.7.0-rc2