### PR TITLE
Provide Gradle 9 forward compatibility.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ subprojects {
       'equalsverifier': '3.8.2',
       'guava':          '29.0-jre',
       'jackson':        '2.13.3',
+      'jdk':            '8',
       'jena':           '3.17.0',
       'jetty':          '9.4.14.v20181114',
       'jquery':         '3.3.1-1',
@@ -66,9 +67,6 @@ subprojects {
 
   check.dependsOn(javadoc)
 
-  sourceCompatibility = '1.8'
-  targetCompatibility = '1.8'
-
   repositories {
     mavenCentral()
     maven githubPackage.invoke("metafacture")
@@ -84,6 +82,18 @@ subprojects {
 
   checkstyle {
     toolVersion '8.44'
+  }
+
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(versions.jdk)
+    }
+  }
+
+  tasks.withType(JavaExec) {
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = java.toolchain.languageVersion
+    }
   }
 
   tasks.withType(JavaCompile) {

--- a/gradle/source-layout.gradle
+++ b/gradle/source-layout.gradle
@@ -22,5 +22,7 @@ jar {
 }
 
 plugins.withId('war') {
-  webAppDirName = 'src/main/webapp'
+  war {
+    webAppDirectory = file('src/main/webapp')
+  }
 }

--- a/metafix-ide/build.gradle
+++ b/metafix-ide/build.gradle
@@ -12,11 +12,13 @@ dependencies {
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-mainClassName = 'org.eclipse.xtext.ide.server.ServerLauncher'
-applicationName = 'xtext-server'
+application {
+  mainClass = 'org.eclipse.xtext.ide.server.ServerLauncher'
+  applicationName = 'xtext-server'
+}
 
 shadowJar {
-  from(project.convention.getPlugin(JavaPluginConvention).sourceSets.main.output)
+  from(sourceSets.main.output)
   configurations = [project.configurations.runtimeClasspath]
 
   exclude(

--- a/metafix/build.gradle
+++ b/metafix/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'maven-publish'
-  id 'me.champeau.jmh' version '0.6.6'
+  id 'me.champeau.jmh' version '0.7.2'
 }
 
 def passSystemProperties = {

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -2310,7 +2310,7 @@ public class MetafixMethodTest {
 
     @Test
     public void copyFieldToSubfieldOfArrayOfStringsWithIndexImplicitAppend() {
-        MetafixTestHelpers.assertProcessException(IndexOutOfBoundsException.class, "Index 0 out of bounds for length 0", () ->
+        MetafixTestHelpers.assertProcessException(IndexOutOfBoundsException.class, "Index: 0, Size: 0", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "set_array('test[]')",
                     "copy_field('key', 'test[].1')"

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.err
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.err
@@ -1,2 +1,2 @@
 ^Exception in thread "main" org\.metafacture\.metafix\.FixProcessException: Error while executing Fix expression \(at .*/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/test\.fix, line 2\): copy_field\("key", "test\[\]\.1"\)$
-^Caused by: java\.lang\.IndexOutOfBoundsException: Index 0 out of bounds for length 0$
+^Caused by: java\.lang\.IndexOutOfBoundsException: Index: 0, Size: 0$

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 include 'metafix'
 include 'metafix-ide'
 include 'metafix-runner'


### PR DESCRIPTION
Follow-up to #341.

There's one more warning when running the `jmh` task:

> Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.6/userguide/upgrading_version_7.html#task_project

Should be fixed by melix/jmh-gradle-plugin#261, but hasn't been released yet.