### PR TITLE
Bump java version from 8 to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
       'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.8.2',
       'junit_platform': '1.4.2',
-      'metafacture':    '6.0.0-rc1-SNAPSHOT',
+      'metafacture':    '5.7.0',
       'mockito':        '2.27.0',
       'requirejs':      '2.3.6',
       'slf4j':          '1.7.21',
@@ -55,7 +55,7 @@ subprojects {
   }
 
   group = 'org.metafacture'
-  version = '1.0.0-SNAPSHOT'
+  version = '0.8.0-SNAPSHOT'
 
   apply plugin: 'checkstyle'
   apply plugin: 'eclipse'

--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,13 @@ subprojects {
       'equalsverifier': '3.8.2',
       'guava':          '29.0-jre',
       'jackson':        '2.13.3',
-      'jdk':            '8',
+      'jdk':            '11',
       'jena':           '3.17.0',
       'jetty':          '9.4.14.v20181114',
       'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.8.2',
       'junit_platform': '1.4.2',
-      'metafacture':    '5.7.0',
+      'metafacture':    '6.0.0-rc1-SNAPSHOT',
       'mockito':        '2.27.0',
       'requirejs':      '2.3.6',
       'slf4j':          '1.7.21',
@@ -55,7 +55,7 @@ subprojects {
   }
 
   group = 'org.metafacture'
-  version = '0.8.0-SNAPSHOT'
+  version = '1.0.0-SNAPSHOT'
 
   apply plugin: 'checkstyle'
   apply plugin: 'eclipse'

--- a/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/MetafixMethodTest.java
@@ -2310,7 +2310,7 @@ public class MetafixMethodTest {
 
     @Test
     public void copyFieldToSubfieldOfArrayOfStringsWithIndexImplicitAppend() {
-        MetafixTestHelpers.assertProcessException(IndexOutOfBoundsException.class, "Index: 0, Size: 0", () ->
+        MetafixTestHelpers.assertProcessException(IndexOutOfBoundsException.class, "Index 0 out of bounds for length 0", () ->
             MetafixTestHelpers.assertFix(streamReceiver, Arrays.asList(
                     "set_array('test[]')",
                     "copy_field('key', 'test[].1')"

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.err
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/expected.err
@@ -1,2 +1,2 @@
 ^Exception in thread "main" org\.metafacture\.metafix\.FixProcessException: Error while executing Fix expression \(at .*/metafix/src/test/resources/org/metafacture/metafix/integration/record/fromJson/toJson/copy_fieldToArrayOfStringsWithIndex/test\.fix, line 2\): copy_field\("key", "test\[\]\.1"\)$
-^Caused by: java\.lang\.IndexOutOfBoundsException: Index: 0, Size: 0$
+^Caused by: java\.lang\.IndexOutOfBoundsException: Index 0 out of bounds for length 0$


### PR DESCRIPTION
 Resolves #343.

Consumes the rc from metafacture-core which also uses java 11. 
(See https://github.com/metafacture/metafacture-core/issues/515).