### PR TITLE
Delete escape signs in default template for find-fix-paths #347

### DIFF
--- a/metafix/src/main/java/org/metafacture/metafix/FindFixPaths.java
+++ b/metafix/src/main/java/org/metafacture/metafix/FindFixPaths.java
@@ -65,7 +65,7 @@ public class FindFixPaths extends DefaultStreamPipe<ObjectReceiver<String>> {
                 .setReceiver(new StreamFlattener())
                 .setReceiver(new StreamToTriples())
                 .setReceiver(tripleFilter)
-                .setReceiver(new ObjectTemplate<>("${p}\\t|\\t${o}"))
+                .setReceiver(new ObjectTemplate<>("${p}\t|\t${o}"))
                 .setReceiver(getReceiver());
     }
 

--- a/metafix/src/test/java/org/metafacture/metafix/FindFixPathsTest.java
+++ b/metafix/src/test/java/org/metafacture/metafix/FindFixPathsTest.java
@@ -46,8 +46,8 @@ public final class FindFixPathsTest {
     @Test
     public void testShouldFindPaths() {
         verify(
-                "a\\t|\\tAn ETL test",
-                "c.2\\t|\\tETL what?");
+                "a\t|\tAn ETL test",
+                "c.2\t|\tETL what?");
     }
 
     private void processRecord() {


### PR DESCRIPTION
See #347