### PR TITLE
Optionally specify limit for number of entities in a record.

### DIFF
--- a/metafix-runner/build.gradle
+++ b/metafix-runner/build.gradle
@@ -49,3 +49,13 @@ application {
     ]
   }
 }
+
+tasks.withType(JavaExec) {
+  doFirst {
+    def prefix = project.group + '.'
+
+    System.properties.each { k, v ->
+      if (k.startsWith(prefix)) systemProperties[k] = v
+    }
+  }
+}

--- a/metafix/integrationTest.sh
+++ b/metafix/integrationTest.sh
@@ -74,7 +74,8 @@ function rm_temp() {
 }
 
 function run_metafix() {
-  $gradle_command --console=plain -p "$root_directory" :metafix-runner:run --args="$1" -P${noprofile}profile="${1%.*}"
+  local file=$1; shift
+  $gradle_command --console=plain -p "$root_directory" :metafix-runner:run --args="$file" -P${noprofile}profile="${file%.*}" $@
 }
 
 function run_catmandu() {
@@ -224,10 +225,11 @@ function run_tests() {
 
       metafix_command_output="$test_directory/metafix.out"
       metafix_command_error="$test_directory/metafix.err"
+      metafix_command_args="$test_directory/metafix.args"
 
       metafix_start_time=$(current_time)
 
-      run_metafix "$test_directory/$metafix_file" >"$metafix_command_output" 2>"$metafix_command_error"
+      run_metafix "$test_directory/$metafix_file" $(cat "$metafix_command_args" 2>/dev/null || true) >"$metafix_command_output" 2>"$metafix_command_error"
       metafix_exit_status=$?
 
       metafix_elapsed_time=$(elapsed_time "$metafix_start_time")

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -239,7 +239,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
         flattener.startRecord(identifier);
         entityCountStack.clear();
         entityCount = 0;
-        entityCountStack.add(Integer.valueOf(entityCount));
+        entityCountStack.add(entityCount);
         recordIdentifier = identifier;
         entities = new ArrayList<>();
     }
@@ -317,13 +317,13 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
         addValue(name, value);
         entities.add(value);
 
-        entityCountStack.push(Integer.valueOf(++entityCount));
+        entityCountStack.push(++entityCount);
         flattener.startEntity(name);
     }
 
     @Override
     public void endEntity() {
-        entityCountStack.pop().intValue();
+        entityCountStack.pop();
         flattener.endEntity();
     }
 

--- a/metafix/src/main/java/org/metafacture/metafix/Metafix.java
+++ b/metafix/src/main/java/org/metafacture/metafix/Metafix.java
@@ -76,6 +76,8 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
 
     public static final Map<String, String> NO_VARS = Collections.emptyMap();
 
+    public static final int MAX_ENTITY_COUNT = Integer.getInteger("org.metafacture.metafix.maxEntityCount", -1);
+
     private static final Logger LOG = LoggerFactory.getLogger(Metafix.class);
 
     private static final String ENTITIES_NOT_BALANCED = "Entity starts and ends are not balanced";
@@ -101,7 +103,6 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
     private boolean repeatedFieldsToEntities;
     private boolean strictnessHandlesProcessExceptions;
     private int entityCount;
-    private int maxEntityCount = Integer.getInteger("org.metafacture.metafix.maxEntityCount", -1);
 
     public Metafix() {
         this(NO_VARS);
@@ -316,7 +317,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
 
         ++entityCount;
         if (maxEntityCountExceeded()) {
-            LOG.debug("Maximum number of entities exceeded: {}/{}", entityCount, maxEntityCount);
+            LOG.debug("Maximum number of entities exceeded: {}/{}", entityCount, MAX_ENTITY_COUNT);
             return;
         }
 
@@ -340,7 +341,7 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
 
     @Override
     public void literal(final String name, final String value) {
-        if (entityCountStack.size() > 1 && maxEntityCountExceeded()) {
+        if (maxEntityCountExceeded()) {
             return;
         }
 
@@ -453,16 +454,8 @@ public class Metafix implements StreamPipe<StreamReceiver>, Maps {
         return entityMemberName;
     }
 
-    public void setMaxEntityCount(final int maxEntityCount) {
-        this.maxEntityCount = maxEntityCount;
-    }
-
-    public int getMaxEntityCount() {
-        return maxEntityCount;
-    }
-
     private boolean maxEntityCountExceeded() {
-        return maxEntityCount >= 0 && entityCount > maxEntityCount;
+        return MAX_ENTITY_COUNT >= 0 && entityCount > MAX_ENTITY_COUNT;
     }
 
     public enum Strictness {

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/expected.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/expected.json
@@ -1,0 +1,3 @@
+{"key1":"value1","key2":"value2","key3":"value3","key4":"value4"}
+{"key1":"value1","key2":["v1","v2"]}
+{"key1":"value1","key2":["v1","v2"],"key3":"value3","key4":"value4"}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/input.json
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/input.json
@@ -1,0 +1,3 @@
+{"key1":"value1","key2":"value2","key3":"value3","key4":"value4"}
+{"key1":"value1","key2":["v1","v2"],"key3":["v3"],"key4":"value4"}
+{"key1":"value1","key2":["v1","v2"],"key3":"value3","key4":"value4"}

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/metafix.args
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/metafix.args
@@ -1,0 +1,1 @@
+-Dorg.metafacture.metafix.maxEntityCount=1

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/test.fix
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/test.fix
@@ -1,0 +1,1 @@
+nothing()

--- a/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/test.flux
+++ b/metafix/src/test/resources/org/metafacture/metafix/integration/script/fromJson/toJson/maxEntityCount/test.flux
@@ -1,0 +1,8 @@
+FLUX_DIR + "input.json"
+|open-file
+|as-lines
+|decode-json
+|fix(FLUX_DIR + "test.fix")
+|encode-json
+|write(FLUX_DIR + "output-metafix.json")
+;


### PR DESCRIPTION
_Just a proof-of-concept to gauge interest in such a feature; the immediate need has been rendered moot (due to the record's holdings being suppressed from publishing now)._

This is a brute-force approach to dealing with OOM situations when Alma records have an excessive number of items (e.g. [99374518570506441](https://lobid.org/resources/99374518570506441): >12000 entities = ~10 GB heap for the Record instance). Loosely modeled after JAXP's [`totalEntitySizeLimit`](https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html#GUID-82F8C206-F2DF-4204-9544-F96155B1D258__TABLE_RQ1_3PY_HHB), except that we don't abort processing but instead skip the remaining entities.
    
~Use Metafix instance setter `setMaxEntityCount(int)` or~ set system property `org.metafacture.metafix.maxEntityCount=<int>`.
    
Alternative options:
    
- Increase maximum heap size for JVM.
- Significantly reduce memory requirement for Record instances.

Possible optimizations (implemented in dc4f1af):

1. Drop the setter and make the limit `static final`; this way the JVM can (potentially) eliminate the check altogether when no limit has been set (less than zero).
2. Skip _all_ remaining literals (instead of just the ones inside entities), thereby simplifying the check in `literal()`.