### PR TITLE
Set wildcard classpath for windows start batch (#371)

### DIFF
--- a/metafix-runner/build.gradle
+++ b/metafix-runner/build.gradle
@@ -2,6 +2,16 @@ plugins {
   id 'application'
 }
 
+application
+  startScripts {
+    doLast {
+        def winScriptFile  = file getWindowsScript()
+        def winFileText = winScriptFile.text
+        winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem original CLASSPATH declaration replaced, see https://github.com/metafacture/metafacture-fix/issues/371:\nset CLASSPATH=%APP_HOME%\\\\lib\\\\\\*')
+        winScriptFile.text = winFileText
+    }
+  }
+
 dependencies {
   implementation project(':metafix')
 


### PR DESCRIPTION
The generated start script for Windows consists of a huge classpath. This classpath was too long, resulting in an error when executing the start script. Using wildcard to include libraries shortens the classpath so that now error occurs when executing the start script.

To test this:
```
./gradlew clean;  ./gradlew distZip
```
then look in `./metafix-runner/build/scripts/metafix-runner.bat` and execute that on windows @maipet.
