### PR TITLE
Add log4j logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ To execute a Fix (embedded in a Flux) via CLI:
 
 `./gradlew :metafix-runner:run --args="$PWD/path/to.flux"`
 
+To execute a Fix (embedded in a Flux) via CLI in java debug mode:
+make sure to pipe to `log-stream` after your `fix` command in flux resp. make
+use of `log-object` at the proper location. Then:
+
+`export JAVA_OPTS="-Dorg.metafacture.metafix.logLevel=DEBUG"; ./gradlew installDist;  cd metafix-runner/build/install/metafix-runner; bin/metafix-runner "$PWD/path/to.flux"`
+
 (To import the projects in Eclipse, choose `File > Import > Existing Gradle Project` and select the `metafacture-fix` directory.)
 
 ## Usage

--- a/metafix-runner/build.gradle
+++ b/metafix-runner/build.gradle
@@ -39,11 +39,15 @@ dependencies {
 application {
   mainClass = 'org.metafacture.runner.Flux'
 
+  applicationDefaultJvmArgs = [
+    "-Dorg.metafacture.metafix.logLevel=INFO"
+  ]
+
   if (project.hasProperty('profile')) {
     def file = project.getProperty('profile') ?: project.name
     def depth = project.hasProperty('profile.depth') ? project.getProperty('profile.depth') : 8
 
-    applicationDefaultJvmArgs = [
+    applicationDefaultJvmArgs += [
       "-XX:FlightRecorderOptions=stackdepth=${depth}",
       "-XX:StartFlightRecording=dumponexit=true,filename=${file}.jfr,settings=profile"
     ]

--- a/metafix/src/main/resources/log4j.xml
+++ b/metafix/src/main/resources/log4j.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/xml/doc-files/log4j.dtd">
+
+<log4j:configuration>
+    <appender name="stdout" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                value="%-5p [%t] [%c{1}] %m%n" />
+        </layout>
+    </appender>
+
+    <root>
+        <priority value="${org.metafacture.metafix.logLevel}" />
+        <appender-ref ref="stdout" />
+    </root>
+
+</log4j:configuration>
+


### PR DESCRIPTION
Enables java logging. The log level can be changed by setting a variable. Set and run like this:
JAVA_OPTS="-Dorg.metafacture.metafix.logLevel=DEBUG"; ./gradlew installDist;  cd metafix-runner/build/install/metafix-runner; bin/metafix-runner $pathTo.flux

See #383.

Substitutes #387.