### PR TITLE
Fix memory leak (metafacture-core#666)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,14 @@ jobs:
         java-version: 1.8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: Install metafacture-core 5.7.1
+      run: |
+        cd ..
+        git clone https://github.com/metafacture/metafacture-core.git
+        cd metafacture-core
+        git checkout metafacture-core-5.7.1
+        ./gradlew publishToMavenLocal
+        cd -
     - name: Build with Gradle
       run: ./gradlew build
       env:

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
       'jquery':         '3.3.1-1',
       'junit_jupiter':  '5.8.2',
       'junit_platform': '1.4.2',
-      'metafacture':    '5.7.0',
+      'metafacture':    '5.7.1',
       'mockito':        '2.27.0',
       'requirejs':      '2.3.6',
       'slf4j':          '1.7.21',
@@ -54,7 +54,7 @@ subprojects {
   }
 
   group = 'org.metafacture'
-  version = '0.8.0-SNAPSHOT'
+  version = '0.7.1'
 
   apply plugin: 'checkstyle'
   apply plugin: 'eclipse'
@@ -72,6 +72,7 @@ subprojects {
   repositories {
     mavenCentral()
     maven githubPackage.invoke("metafacture")
+    mavenLocal()
   }
 
   dependencies {

--- a/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
+++ b/metafix/src/main/java/org/metafacture/metafix/maps/RdfMap.java
@@ -31,6 +31,7 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.shared.PropertyNotFoundException;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -56,7 +57,7 @@ import java.util.function.UnaryOperator;
  *
  * @see org.metafacture.metamorph.maps.FileMap
  */
-public final class RdfMap extends AbstractReadOnlyMap<String, String> {
+public final class RdfMap extends AbstractReadOnlyMap<String, String> implements Closeable {
 
     public static final String SELECT = "select";
     public static final String TARGET = "target";
@@ -392,6 +393,14 @@ public final class RdfMap extends AbstractReadOnlyMap<String, String> {
         }
 
         return conn.getURL().toString();
+    }
+
+    @Override
+    public void close() {
+        map.clear();
+        if (model != null) {
+            model.close();
+        }
     }
 
     private enum Select {


### PR DESCRIPTION
DON'T MERGE THIS PR!

Fixes a memory leak for old  programs running java 8.

This is a branch which fixes a memory leak (see  (metafacture-core#666)). It's build on the latest release which uses java 8.

Resolves https://github.com/metafacture/metafacture-core/issues/666#issuecomment-2706080485.

Use like:
look at the needed metafacture-core 5.7.1 dependency build as noted in https://github.com/metafacture/metafacture-fix/blob/publish-0.7.1-fixMemoryLeak/.github/workflows/build.yml. Then:
`git checkout 0.7.1;  /gradlew publishToMavenLocal`.  You can then consume the locally build `metafix/0.7.1`